### PR TITLE
feat: add support for tags  externalDocs url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules
+test/output

--- a/README.md
+++ b/README.md
@@ -18,3 +18,10 @@ npm install -g @asyncapi/generator
 |---|---|---|---|---|
 |sidebarOrganization|Defines how the sidebar should be organized. Set its value to 'byTags' to categorize operations by tags.|No|`byTags`|`byTags`|
 |baseHref|Sets the base URL for links and forms.|No|*Any*|`/docs`|
+
+## Development
+
+1. Make sure you have the latest generator installed `npm install -g @asyncapi/generator`.
+1. Modify the template or it's helper functions. Adjust `test/spec/asyncapi.yml` to have more features if needed.
+1. Generate output with watcher enables `npm run develop`.
+1. Open HTML in your browser `open ./test/output/index.html`.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "scripts": {
     "test": "echo \"No test specified yet\"",
     "release": "semantic-release",
-    "get-version": "echo $npm_package_version"
+    "get-version": "echo $npm_package_version",
+    "develop": "ag test/spec/asyncapi.yml ./ -o test/output --force-write --watch-template"
   },
   "publishConfig": {
     "access": "public"

--- a/partials/message.html
+++ b/partials/message.html
@@ -1,4 +1,5 @@
 {% from "./schema.html" import schema %}
+{% from "./tags.html" import tags %}
 
 {% macro message(msg, showIndex=false, index=0, open=false) %}
 
@@ -19,6 +20,9 @@
     {% endif %}
   </div>
   <p class="text-grey-dark text-sm">{{msg.summary()}}</p>
+  
+  {{ tags(msg.tags()) }}
+
   <div class="mt-4 mb-4 markdown">{{ msg.description() | markdown2html | safe }}</div>
   {{ schema(msg.payload(), 'Payload', open=open) }}
   {% if msg.headers() %}

--- a/partials/tags.html
+++ b/partials/tags.html
@@ -3,7 +3,7 @@
 <div class="mt-4">
   {% for tag in tagList %}
       {% if tag.externalDocs() %}
-        <span class="bg-grey-dark font-normal text-sm no-underline text-white rounded lowercase mr-2 px-2 py-1" title="{{tag.description()}}"><a href="{{tag.externalDocs().url()}}" target="_blank">{{tag.name()}}</a></span>
+        <a href="{{tag.externalDocs().url()}}" target="_blank" class="bg-grey-dark font-normal text-sm text-white rounded lowercase mr-2 px-2 py-1" title="{{tag.description()}}">{{tag.name()}}</a>
       {% else %}
         <span class="bg-grey-dark font-normal text-sm no-underline text-white rounded lowercase mr-2 px-2 py-1" title="{{tag.description()}}">{{tag.name()}}</span>
       {% endif %}

--- a/partials/tags.html
+++ b/partials/tags.html
@@ -1,8 +1,14 @@
 {% macro tags(tagList) %}
+{% if tagList %}
 <div class="mt-4">
   {% for tag in tagList %}
-    <span class="bg-grey-dark font-normal text-sm no-underline text-white rounded lowercase mr-2 px-2 py-1" title="{{tag.description()}}">{{tag.name()}}</span>
+      {% if tag.externalDocs() %}
+        <span class="bg-grey-dark font-normal text-sm no-underline text-white rounded lowercase mr-2 px-2 py-1" title="{{tag.description()}}"><a href="{{tag.externalDocs().url()}}" target="_blank">{{tag.name()}}</a></span>
+      {% else %}
+        <span class="bg-grey-dark font-normal text-sm no-underline text-white rounded lowercase mr-2 px-2 py-1" title="{{tag.description()}}">{{tag.name()}}</span>
+      {% endif %}
   {% endfor %}
 </div>
+{% endif %}
 
 {% endmacro %}

--- a/partials/tags.html
+++ b/partials/tags.html
@@ -3,9 +3,9 @@
 <div class="mt-4">
   {% for tag in tagList %}
       {% if tag.externalDocs() %}
-        <a href="{{tag.externalDocs().url()}}" target="_blank" class="bg-grey-dark font-normal text-sm text-white rounded lowercase mr-2 px-2 py-1" title="{{tag.description()}}">{{tag.name()}}</a>
+        <a href="{{tag.externalDocs().url()}}" target="_blank" class="border text-blue-light font-normal text-sm rounded lowercase mr-2 px-2 py-1" title="{{tag.description()}}">{{tag.name()}}</a>
       {% else %}
-        <span class="bg-grey-dark font-normal text-sm no-underline text-white rounded lowercase mr-2 px-2 py-1" title="{{tag.description()}}">{{tag.name()}}</span>
+        <span class="border font-normal text-sm no-underline text-blue-light rounded lowercase mr-2 px-2 py-1" title="{{tag.description()}}">{{tag.name()}}</span>
       {% endif %}
   {% endfor %}
 </div>

--- a/test/spec/asyncapi.yml
+++ b/test/spec/asyncapi.yml
@@ -1,0 +1,234 @@
+asyncapi: '2.0.0'
+info:
+  title: Streetlights API
+  version: '1.0.0'
+  description: |
+    The Smartylighting Streetlights API allows you to remotely manage the city lights.
+
+    ### Check out its awesome features:
+
+    * Turn a specific streetlight on/off 🌃
+    * Dim a specific streetlight 😎
+    * Receive real-time information about environmental lighting conditions 📈
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+
+servers:
+  production:
+    url: mqtt://test.mosquitto.org:{port}
+    protocol: mqtt
+    description: Test broker
+    variables:
+      port:
+        description: Secure connection (TLS) is available through port 8883.
+        default: '1883'
+        enum:
+          - '1883'
+          - '8883'
+
+defaultContentType: application/json
+
+channels:
+  smartylighting/streetlights/1/0/event/{streetlightId}/lighting/measured:
+    description: The topic on which measured values may be produced and consumed.
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    publish:
+      summary: Inform about environmental lighting conditions of a particular streetlight.
+      operationId: receiveLightMeasurement
+      tags:
+        - name: oparation-tag1
+          externalDocs: 
+            description: External docs description 1
+            url: https://www.asyncapi.com/
+        - name: oparation-tag2
+          description: Description 2
+          externalDocs:
+            url: "https://www.asyncapi.com/"
+        - name: oparation-tag3
+        - name: oparation-tag4
+          description: Description 4
+        - name: message-tag5
+          externalDocs:  
+            url: "https://www.asyncapi.com/"
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/lightMeasured'
+
+  smartylighting/streetlights/1/0/action/{streetlightId}/turn/on:
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    subscribe:
+      operationId: turnOn
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/turnOnOff'
+
+  smartylighting/streetlights/1/0/action/{streetlightId}/turn/off:
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    subscribe:
+      operationId: turnOff
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/turnOnOff'
+
+  smartylighting/streetlights/1/0/action/{streetlightId}/dim:
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    subscribe:
+      operationId: dimLight
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/dimLight'
+
+components:
+  messages:
+    lightMeasured:
+      name: lightMeasured
+      title: Light measured
+      summary: Inform about environmental lighting conditions of a particular streetlight.
+      contentType: application/json
+      tags:
+        - name: message-tag1
+          externalDocs: 
+            description: External docs description 1
+            url: https://www.asyncapi.com/
+        - name: message-tag2
+          description: Description 2
+          externalDocs:
+            url: "https://www.asyncapi.com/"
+        - name: message-tag3
+        - name: message-tag4
+          description: Description 4
+        - name: message-tag5
+          externalDocs:  
+            url: "https://www.asyncapi.com/"
+      traits:
+        - $ref: '#/components/messageTraits/commonHeaders'
+      payload:
+        $ref: "#/components/schemas/lightMeasuredPayload"
+    turnOnOff:
+      name: turnOnOff
+      title: Turn on/off
+      summary: Command a particular streetlight to turn the lights on or off.
+      traits:
+        - $ref: '#/components/messageTraits/commonHeaders'
+      payload:
+        $ref: "#/components/schemas/turnOnOffPayload"
+    dimLight:
+      name: dimLight
+      title: Dim light
+      summary: Command a particular streetlight to dim the lights.
+      traits:
+        - $ref: '#/components/messageTraits/commonHeaders'
+      payload:
+        $ref: "#/components/schemas/dimLightPayload"
+
+  schemas:
+    lightMeasuredPayload:
+      type: object
+      properties:
+        lumens:
+          type: integer
+          minimum: 0
+          description: Light intensity measured in lumens.
+          x-pi: false
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+    turnOnOffPayload:
+      type: object
+      properties:
+        command:
+          type: string
+          enum:
+            - on
+            - off
+          description: Whether to turn on or off the light.
+          x-pi: false
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+    dimLightPayload:
+      type: object
+      properties:
+        percentage:
+          type: integer
+          description: Percentage to which the light should be dimmed to.
+          minimum: 0
+          maximum: 100
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+    sentAt:
+      type: string
+      format: date-time
+      description: Date and time when the message was sent.
+
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: user
+      description: Provide your API key as the user and leave the password empty.
+    supportedOauthFlows:
+      type: oauth2
+      description: Flows to support OAuth 2.0
+      flows:
+        implicit:
+          authorizationUrl: 'https://authserver.example/auth'
+          scopes:
+            'streetlights:on': Ability to switch lights on
+            'streetlights:off': Ability to switch lights off
+            'streetlights:dim': Ability to dim the lights
+        password:
+          tokenUrl: 'https://authserver.example/token'
+          scopes:
+            'streetlights:on': Ability to switch lights on
+            'streetlights:off': Ability to switch lights off
+            'streetlights:dim': Ability to dim the lights
+        clientCredentials:
+          tokenUrl: 'https://authserver.example/token'
+          scopes:
+            'streetlights:on': Ability to switch lights on
+            'streetlights:off': Ability to switch lights off
+            'streetlights:dim': Ability to dim the lights
+        authorizationCode:
+          authorizationUrl: 'https://authserver.example/auth'
+          tokenUrl: 'https://authserver.example/token'
+          refreshUrl: 'https://authserver.example/refresh'
+          scopes:
+            'streetlights:on': Ability to switch lights on
+            'streetlights:off': Ability to switch lights off
+            'streetlights:dim': Ability to dim the lights
+    openIdConnectWellKnown:
+      type: openIdConnect
+      openIdConnectUrl: 'https://authserver.example/.well-known'
+
+  parameters:
+    streetlightId:
+      description: The ID of the streetlight.
+      schema:
+        type: string
+
+  messageTraits:
+    commonHeaders:
+      headers:
+        type: object
+        properties:
+          my-app-header:
+            type: integer
+            minimum: 0
+            maximum: 100
+
+  operationTraits:
+    kafka:
+      bindings:
+        kafka:
+          clientId: my-app-id


### PR DESCRIPTION
**Description**

- add support for tags  externalDocs url and tags in general in messages
- added one additional if in tag macro to not get empty div in case of no tags
- added some development help

I choose to not use externalDocs.description as it would complicate first iteration a lot. There are too many combinations available in case if we want to support `externalDocs.description` because we would have to take into account that user would like to use `description` like `Click here for more info` to the tag could not be clickable link but somehow the text inside tooltip.

Now, in case `url` is provided, the `name` of the tag becomes a hyperlink as discussed in the issue.

To test it with your spec just run `ag <your-asyncapi-file> https://github.com/derberg/html-template#support-tags`

<img width="807" alt="Screenshot 2020-04-15 at 15 06 16" src="https://user-images.githubusercontent.com/6995927/79340831-2d62ea80-7f2b-11ea-8f6f-2c030868a0fd.png">

**Related issue(s)**
Fixes #6 and #5 