### PR TITLE
refactor: remove unnecessary handling of isArray case

### DIFF
--- a/partials/schema-prop.html
+++ b/partials/schema-prop.html
@@ -149,7 +149,7 @@
             {% endif %}
           {% endif %}
 
-          {% if prop.additionalItems() | isArray or prop.additionalItems() === true or prop.additionalItems() === undefined %}
+          {% if prop.additionalItems() === true or prop.additionalItems() === undefined %}
             <p class="pl-6 mb-2 mt-4 text-xs text-grey-darker">Additional items are allowed.</p>
           {% elif prop.additionalItems() === false %}
             <p class="pl-6 mb-2 mt-4 text-xs text-grey-darker">Additional items are NOT allowed.</p>
@@ -162,7 +162,7 @@
         {% endif %}
 
         {% if prop.type() === 'object' %}
-          {% if prop.additionalProperties() | isArray or prop.additionalProperties() === true or prop.additionalProperties() === undefined or prop.additionalProperties() === null %}
+          {% if prop.additionalProperties() === true or prop.additionalProperties() === undefined or prop.additionalProperties() === null %}
             <p class="pl-6 mb-2 mt-4 text-xs text-grey-darker">Additional properties are allowed.</p>
           {% elif prop.additionalProperties() === false %}
             <p class="pl-6 mb-2 mt-4 text-xs text-grey-darker">Additional properties are <strong>NOT</strong> allowed.</p>

--- a/test/spec/asyncapi.yml
+++ b/test/spec/asyncapi.yml
@@ -145,6 +145,7 @@ components:
           x-pi: false
         sentAt:
           $ref: "#/components/schemas/sentAt"
+      additionalProperties: false
     turnOnOffPayload:
       type: object
       properties:


### PR DESCRIPTION
**Description**

According to the JSON Schema, and our parser (https://github.com/asyncapi/parser-js/blob/master/lib/models/schema.js#L195), `additionalProperties` and `additionalItems` are allowed to be boolean or an object, never an array - and yet the HTML template handles this case.

Can anyone confirm this, or have I misunderstood somewhere along the way? 

**Related issue(s)**

I noticed this while exploring another issue (https://github.com/asyncapi/html-template/issues/11), but wanted to sense check.