### PR TITLE
feat: flatten allOf cases in message payloads 

### DIFF
--- a/filters/all.js
+++ b/filters/all.js
@@ -107,7 +107,10 @@ module.exports = ({ Nunjucks }) => {
   Nunjucks.addFilter('isArray', (arr) => {
     return Array.isArray(arr);
   });
-
+  
+  Nunjucks.addFilter('additionalPropertiesAllowedForAll', (items) => items.every(p => p.additionalProperties() === true || p.additionalProperties() === undefined || p.additionalProperties() === null));
+  Nunjucks.addFilter('additionalPropertiesDisabledForAll', (items) => items.every(p => p.additionalProperties() === false) );
+  
   Nunjucks.addFilter('isObject', (obj) => {
     return typeof obj === 'object' && obj !== null;
   });

--- a/partials/schema-prop.html
+++ b/partials/schema-prop.html
@@ -194,6 +194,26 @@
               {{ schemaProp(pChild, pName, odd=(not odd), required=(p.required() | contains(pName))) }}
             {% endfor %}
           {% endfor %}
+          {# allOf requires *all* provided schemas to successfully validate a message
+             and so 'additionalProperties' can be problematic.
+             See https://json-schema.org/understanding-json-schema/reference/combining.html#allof
+             Therefore, I suspect most scenarios other than the one where additionalProperties 
+             are allowed in every schema are likely to be edge cases
+          #}
+          {% if prop.allOf() | additionalPropertiesAllowedForAll %}
+            <p class="pl-6 mb-2 mt-4 text-xs text-grey-darker">Additional properties are allowed.</p>
+          {% elif prop.allOf() | additionalPropertiesDisabledForAll %}
+            <p class="pl-6 mb-2 mt-4 text-xs text-grey-darker">Additional properties are <strong>NOT</strong> allowed.</p>
+          {% else %}
+            <p class="pl-6 mb-2 mt-4 text-xs font-bold text-grey-darker">Additional properties must adhere to the following schema:</p>
+            {% for p in prop.allOf() %}
+              {% if p.additionalProperties() | isObject %}
+                <div class="{% if odd %}bg-grey-lightest{% else %}bg-grey-lighter{% endif %} pl-6">
+                  {{ schemaProp(p.additionalProperties(), '(property name)', odd=(not odd), open=false, specialName=true) }}
+                </div>
+              {% endif %}
+            {% endfor %}
+          {% endif %}
         {% endif %}
       </div>
     {% endif %}

--- a/partials/schema-prop.html
+++ b/partials/schema-prop.html
@@ -5,6 +5,7 @@
 <div class="{% if odd %}bg-grey-lighter{% else %}bg-grey-lightest{% endif %} {% if not root %}pl-8 pr-8{% endif %} rounded">
   <div class="{% if open %}is-open{% endif %}">
     <div class="{% if prop | isExpandable %}js-prop cursor-pointer py-2{% endif %} flex property">
+      {% if (not prop.allOf()) %}
       <div class="pr-4" style="margin-top:-2px; min-width: 25%;">
         <span class="text-sm {% if specialName %}italic text-grey{% endif %}" style="word-break: break-word;">{{propName}}</span>
         {% if prop | isExpandable %}
@@ -23,7 +24,7 @@
           {{ type(prop) }}
           {% if prop.anyOf() %}anyOf{% endif %}
           {% if prop.oneOf() %}oneOf{% endif %}
-          {% if prop.allOf() %}allOf{% endif %}
+          
           <div class="inline-block">
             {% if prop.format() %}
               <span class="bg-yellow-dark font-bold no-underline text-black rounded lowercase ml-2"
@@ -98,6 +99,7 @@
           </div>
         {% endif %}
       </div>
+      {% endif %}
     </div>
 
     {% if prop | isExpandable %}
@@ -188,7 +190,9 @@
 
         {% if prop.allOf() %}
           {% for p in prop.allOf() %}
-            {{ schemaProp(p, loop.index0, odd=(not odd)) }}
+            {% for pName, pChild in p.properties() %}
+              {{ schemaProp(pChild, pName, odd=(not odd), required=(p.required() | contains(pName))) }}
+            {% endfor %}
           {% endfor %}
         {% endif %}
       </div>


### PR DESCRIPTION
**Description**

This PR flattens usage of 'allOf' in message payloads. Usage of 'additionalProperties' can be problematic when using allOf, as it requires *all* provided schemas to successfully validate a message. See https://json-schema.org/understanding-json-schema/reference/combining.html#allof. 

Therefore, most scenarios other than when 'additionalProperties' are permitted in every schema are likely to be edge cases as far as I can tell. Feedback especially welcome on this issue.

*Note*: I have based this off the changes in https://github.com/asyncapi/html-template/pull/13 for now

**Related issue(s)**

(Attempts) to Fix #11 