### PR TITLE
feat: Flag deprecated properties

### DIFF
--- a/partials/schema-prop.html
+++ b/partials/schema-prop.html
@@ -6,7 +6,7 @@
   <div class="{% if open %}is-open{% endif %}">
     <div class="{% if prop | isExpandable %}js-prop cursor-pointer py-2{% endif %} flex property">
       <div class="pr-4" style="margin-top:-2px; min-width: 25%;">
-        <span class="text-sm {% if specialName %}italic text-grey{% endif %}" style="word-break: break-word;">{{propName}}</span>
+        <span class="text-sm{% if specialName %} italic text-grey{% endif %}{% if prop.deprecated() %} line-through{% endif %}" style="word-break: break-word;">{{propName}}</span>
         {% if prop | isExpandable %}
         <svg class="expand" version="1.1" viewBox="0 0 24 24" x="0"
           xmlns="http://www.w3.org/2000/svg" y="0">
@@ -15,6 +15,9 @@
         {% endif %}
         {% if required %}
           <div class="text-red-dark text-xs">required</div>
+        {% endif %}
+        {% if prop.deprecated() %}
+          <div class="text-red-dark text-xs">deprecated</div>
         {% endif %}
       </div>
 


### PR DESCRIPTION
**Description**

Now that https://github.com/asyncapi/parser-js/issues/78#issuecomment-620469576 has been resolved, and deprecated() is available, flag properties that have the deprecated attribute.

**Note** I'm not sure how to show that we now have a dependency on parser-js > 0.18.3?

```
cb_hardware_version:
    type: string
    deprecated: true
```

is displayed as:

<img width="557" alt="Screenshot 2020-04-28 at 18 53 29" src="https://user-images.githubusercontent.com/509533/80467770-a7f72580-8981-11ea-873c-de1566065dde.png">
