### PR TITLE
feat: add generator config param

### DIFF
--- a/.tp-config.json
+++ b/.tp-config.json
@@ -8,5 +8,6 @@
       "description": "Sets the base URL for links and forms.",
       "required": false
     }
-  }
+  },
+  "generator": "<2.0.0"
 }

--- a/.tp-config.json
+++ b/.tp-config.json
@@ -9,5 +9,5 @@
       "required": false
     }
   },
-  "generator": "<2.0.0"
+  "generator": ">=0.40.1 <2.0.0"
 }


### PR DESCRIPTION
**Description**
Adds `generator` to the config file to indicate the version-range it's compatible with. The reason I'm choosing this minimum version is this PR: https://github.com/asyncapi/html-template/pull/17.

**Related issue(s)**
Partially solves https://github.com/asyncapi/generator/issues/280