### PR TITLE
feat: Add flag to use operations tags instead of root tags for the sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install -g @asyncapi/generator
 
 |Name|Description|Required|Allowed values|Example|
 |---|---|---|---|---|
-|sidebarOrganization|Defines how the sidebar should be organized. Set its value to 'byTags' to categorize operations by tags.|No|`byTags`|`byTags`|
+|sidebarOrganization|Defines how the sidebar should be organized. Set its value to `byTagsNoRoot` to categorize operations by operations tags. Set its value to `byTags` when you have tags on a root level. These tags are used to model tags navigation and need to have the same tags in operations.|No|`byTags`, `byTagsNoRoot`|`byTagsNoRoot`|
 |baseHref|Sets the base URL for links and forms.|No|*Any*|`/docs`|
 
 ## Development

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,16 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@apidevtools/json-schema-ref-parser": {
+      "version": "github:fmvilas/json-schema-ref-parser#36b39b7e166359b89339f72a69e585789bc3f247",
+      "from": "github:fmvilas/json-schema-ref-parser#add-more-info-about-errors",
+      "dev": true,
+      "requires": {
+        "@jsdevtools/ono": "^7.1.0",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^3.13.1"
+      }
+    },
     "@asyncapi/generator-filters": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@asyncapi/generator-filters/-/generator-filters-1.0.0.tgz",
@@ -13,6 +23,29 @@
         "markdown-it": "^10.0.0",
         "openapi-sampler": "^1.0.0-beta.15"
       }
+    },
+    "@asyncapi/parser": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-0.27.0.tgz",
+      "integrity": "sha512-qFmUQhRAEXWub/9NxDhI11Iz0ZpLWAQtA60mipd//692PuvGTR4YasERVzmmmIeqvBwIJHtWyvknoiXTh7/twA==",
+      "dev": true,
+      "requires": {
+        "@apidevtools/json-schema-ref-parser": "github:fmvilas/json-schema-ref-parser#add-more-info-about-errors",
+        "@asyncapi/specs": "^2.7.1",
+        "@fmvilas/pseudo-yaml-ast": "^0.3.1",
+        "ajv": "^6.10.1",
+        "js-yaml": "^3.13.1",
+        "json-to-ast": "^2.1.0",
+        "node-fetch": "^2.6.0",
+        "re2": "^1.15.0",
+        "tiny-merge-patch": "^0.1.2"
+      }
+    },
+    "@asyncapi/specs": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-2.7.2.tgz",
+      "integrity": "sha512-OBRBP0/9bzheBq/CzeD375/1+MwfdFlip5FP1rrqKvnNOeubAUYxuWcmKhri/eNtwAeEl4KTpnMKWB4/q/FayQ==",
+      "dev": true
     },
     "@babel/code-frame": {
       "version": "7.8.3",
@@ -57,6 +90,21 @@
       "requires": {
         "arrify": "^1.0.1"
       }
+    },
+    "@fmvilas/pseudo-yaml-ast": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@fmvilas/pseudo-yaml-ast/-/pseudo-yaml-ast-0.3.1.tgz",
+      "integrity": "sha512-8OAB74W2a9M3k9bjYD8AjVXkX+qO8c0SqNT5HlgOqx7AxSw8xdksEcZp7gFtfi+4njSxT6+76ZR+1ubjAwQHOg==",
+      "dev": true,
+      "requires": {
+        "yaml-ast-parser": "0.0.43"
+      }
+    },
+    "@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
@@ -597,6 +645,12 @@
         "through": ">=2.2.7 <3"
       }
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
     "acorn": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
@@ -634,6 +688,18 @@
           "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
           "dev": true
         }
+      }
+    },
+    "ajv": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+      "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ansi-align": {
@@ -733,6 +799,22 @@
         "picomatch": "^2.0.4"
       }
     },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "dev": true,
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -777,10 +859,31 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
     "astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "at-least-node": {
@@ -1049,11 +1152,32 @@
         }
       }
     },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
+      "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
+      "dev": true
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "before-after-hook": {
       "version": "2.1.0",
@@ -1222,6 +1346,12 @@
         }
       }
     },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1255,6 +1385,12 @@
         "redeyed": "~2.1.0"
       }
     },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -1281,6 +1417,12 @@
         "normalize-path": "~3.0.0",
         "readdirp": "~3.4.0"
       }
+    },
+    "chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true
     },
     "chunkd": {
       "version": "2.0.1",
@@ -1378,6 +1520,12 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "code-error-fragment": {
+      "version": "0.0.230",
+      "resolved": "https://registry.npmjs.org/code-error-fragment/-/code-error-fragment-0.0.230.tgz",
+      "integrity": "sha512-cadkfKp6932H8UkhzE/gcUqhRMNf8jHzkAN7+5Myabswaghu4xABTgPHDCjW+dBAJxj/SpkTYokpzDqY4pCzQw==",
+      "dev": true
+    },
     "code-excerpt": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-2.1.1.tgz",
@@ -1386,6 +1534,12 @@
       "requires": {
         "convert-to-spaces": "^1.0.1"
       }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
     },
     "color-convert": {
       "version": "1.9.3",
@@ -1407,6 +1561,15 @@
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
       "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "commander": {
       "version": "2.20.3",
@@ -1491,6 +1654,12 @@
           "dev": true
         }
       }
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
     },
     "conventional-changelog-angular": {
       "version": "5.0.6",
@@ -1646,6 +1815,15 @@
         "array-find-index": "^1.0.1"
       }
     },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "date-time": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/date-time/-/date-time-3.1.0.tgz",
@@ -1767,6 +1945,18 @@
         }
       }
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
+    },
     "deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
@@ -1813,6 +2003,16 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
     },
     "emittery": {
       "version": "0.7.0",
@@ -1934,6 +2134,12 @@
         }
       }
     },
+    "env-paths": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
+      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
+      "dev": true
+    },
     "equal-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/equal-length/-/equal-length-1.0.1.tgz",
@@ -1988,6 +2194,24 @@
         "strip-eof": "^1.0.0"
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
     "fast-diff": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
@@ -2007,6 +2231,12 @@
         "micromatch": "^4.0.2",
         "picomatch": "^2.2.1"
       }
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "fastq": {
       "version": "1.6.1",
@@ -2058,6 +2288,23 @@
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
     "from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -2080,6 +2327,15 @@
         "universalify": "^1.0.0"
       }
     },
+    "fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2092,6 +2348,59 @@
       "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
       "dev": true,
       "optional": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -2106,6 +2415,15 @@
       "dev": true,
       "requires": {
         "pump": "^3.0.0"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
       }
     },
     "git-log-parser": {
@@ -2214,6 +2532,12 @@
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true
     },
+    "grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true
+    },
     "handlebars": {
       "version": "4.7.3",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.3.tgz",
@@ -2226,10 +2550,32 @@
         "uglify-js": "^3.1.4"
       }
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
     "has-yarn": {
@@ -2265,6 +2611,17 @@
         "@tootallnate/once": "1",
         "agent-base": "6",
         "debug": "4"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-proxy-agent": {
@@ -2370,6 +2727,12 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
+    },
+    "install-artifact-from-github": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/install-artifact-from-github/-/install-artifact-from-github-1.0.2.tgz",
+      "integrity": "sha512-yuMFBSVIP3vD0SDBGUqeIpgOAIlFx8eQFknQObpkYEM5gsl9hy6R9Ms3aV+Vw9MMyYsoPMeex0XDnfgY7uzc+Q==",
       "dev": true
     },
     "into-stream": {
@@ -2551,6 +2914,12 @@
       "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
       "dev": true
     },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
     "issue-parser": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-6.0.0.tgz",
@@ -2592,6 +2961,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
@@ -2612,11 +2987,33 @@
         "foreach": "^2.0.4"
       }
     },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
+    },
+    "json-to-ast": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/json-to-ast/-/json-to-ast-2.1.0.tgz",
+      "integrity": "sha512-W9Lq347r8tA1DfMvAGn9QNcgYm4Wm7Yc+k8e6vezpMnRT+NHbtlxgNBXRVjXe9YM6eTn6+p/MKOlV/aABJcSnQ==",
+      "dev": true,
+      "requires": {
+        "code-error-fragment": "0.0.230",
+        "grapheme-splitter": "^1.0.4"
+      }
     },
     "jsonfile": {
       "version": "6.0.1",
@@ -2633,6 +3030,18 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
     },
     "keyv": {
       "version": "3.1.0",
@@ -2985,6 +3394,21 @@
       "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
       "dev": true
     },
+    "mime-db": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.44.0"
+      }
+    },
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -3022,6 +3446,47 @@
         "is-plain-obj": "^1.1.0"
       }
     },
+    "minipass": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "minizlib": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.0.tgz",
+      "integrity": "sha512-EzTZN/fjSvifSX0SlqUERCN39o6T40AMarPbv0MrarSFtIITCBh7bi+dU8nxGFHuqs9jdIAeoYoKuQAAASsPPA==",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true
+    },
     "modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
@@ -3038,6 +3503,12 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
       "dev": true
     },
     "neo-async": {
@@ -3072,6 +3543,60 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
       "dev": true
+    },
+    "node-gyp": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.0.0.tgz",
+      "integrity": "sha512-ZW34qA3CJSPKDz2SJBHKRvyNQN0yWO5EGKKksJc+jElu9VA468gwJTyTArC1iOXU7rN3Wtfg/CMt/dBAOFIjvg==",
+      "dev": true,
+      "requires": {
+        "env-paths": "^2.2.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.3",
+        "nopt": "^4.0.3",
+        "npmlog": "^4.1.2",
+        "request": "^2.88.2",
+        "rimraf": "^2.6.3",
+        "semver": "^7.3.2",
+        "tar": "^6.0.1",
+        "which": "^2.0.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "nopt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+      "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+      "dev": true,
+      "requires": {
+        "abbrev": "1",
+        "osenv": "^0.1.4"
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -6647,6 +7172,36 @@
         "path-key": "^2.0.0"
       }
     },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6759,6 +7314,12 @@
         }
       }
     },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
     "os-name": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
@@ -6767,6 +7328,22 @@
       "requires": {
         "macos-release": "^2.2.0",
         "windows-release": "^3.1.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "p-cancelable": {
@@ -6932,6 +7509,12 @@
         "pify": "^3.0.0"
       }
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -7044,6 +7627,12 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "dev": true
+    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -7053,6 +7642,12 @@
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "pupa": {
       "version": "2.0.1",
@@ -7067,6 +7662,12 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
     "quick-lru": {
@@ -7085,6 +7686,17 @@
         "ini": "~1.3.0",
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
+      }
+    },
+    "re2": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/re2/-/re2-1.15.4.tgz",
+      "integrity": "sha512-7w3K+Daq/JjbX/dz5voMt7B9wlprVBQnMiypyCojAZ99kcAL+3LiJ5uBoX/u47l8eFTVq3Wj+V0pmvU+CT8tOg==",
+      "dev": true,
+      "requires": {
+        "install-artifact-from-github": "^1.0.2",
+        "nan": "^2.14.1",
+        "node-gyp": "^7.0.0"
       }
     },
     "read-pkg": {
@@ -7175,6 +7787,34 @@
         "rc": "^1.2.8"
       }
     },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7261,6 +7901,12 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
     "semantic-release": {
@@ -7713,6 +8359,23 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
     "stack-utils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.2.tgz",
@@ -7865,6 +8528,28 @@
         }
       }
     },
+    "tar": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.2.tgz",
+      "integrity": "sha512-Glo3jkRtPcvpDlAs/0+hozav78yoXKFr+c4wgw62NNMO3oo4AaJdCo21Uu7lcwr55h39W2XD1LMERc64wtbItg==",
+      "dev": true,
+      "requires": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.0",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
     "temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -7930,6 +8615,12 @@
       "integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
       "dev": true
     },
+    "tiny-merge-patch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tiny-merge-patch/-/tiny-merge-patch-0.1.2.tgz",
+      "integrity": "sha1-Lo3tGcVuoV29OtTtXbHI5a1UTDw=",
+      "dev": true
+    },
     "to-readable-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
@@ -7943,6 +8634,16 @@
       "dev": true,
       "requires": {
         "is-number": "^7.0.0"
+      }
+    },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       }
     },
     "traverse": {
@@ -7961,6 +8662,21 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
       "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
     "type-fest": {
@@ -8091,6 +8807,15 @@
         }
       }
     },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "url-join": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
@@ -8112,6 +8837,12 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "dev": true
+    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -8120,6 +8851,17 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
       }
     },
     "wcwidth": {
@@ -8151,6 +8893,48 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "widest-line": {
       "version": "3.1.0",
@@ -8264,6 +9048,12 @@
       "requires": {
         "@babel/runtime": "^7.8.7"
       }
+    },
+    "yaml-ast-parser": {
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+      "dev": true
     },
     "yargs": {
       "version": "15.3.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@asyncapi/generator-filters": "^1.0.0"
   },
   "devDependencies": {
+    "@asyncapi/parser": "^0.27.0",
     "@semantic-release/commit-analyzer": "^8.0.1",
     "@semantic-release/github": "^7.0.4",
     "@semantic-release/npm": "^7.0.3",
@@ -64,7 +65,7 @@
   "generator": {
     "parameters": {
       "sidebarOrganization": {
-        "description": "Defines how the sidebar should be organized. Set its value to 'byTags' to categorize operations by tags.",
+        "description": "Defines how the sidebar should be organized. 'byTags' to categorize operations by tags in the root of the document, `byTagsNoRoot` does the same but for pub/sub tags.",
         "required": false
       },
       "baseHref": {

--- a/partials/operations/by_tags.html
+++ b/partials/operations/by_tags.html
@@ -1,0 +1,110 @@
+{% if asyncapi.hasTags() %}
+  {% for categorytags in asyncapi.tags() %}
+    <div class="mt-4 {% if open %}is-open{% endif %}">
+      <div class="js-prop cursor-pointer py-2 flex property">
+        <div class="pr-4" style="margin-top:-2px; min-width: 25%;">
+          <span class="text-sm"
+            style="word-break: break-word;text-transform: capitalize;">{{ categorytags.name() }}</span>
+          <svg class="expand" version="1.1" viewBox="0 0 24 24" x="0" xmlns="http://www.w3.org/2000/svg" y="0">
+            <polygon points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "></polygon>
+          </svg>
+        </div>
+      </div>
+
+      <div class="children">
+        {% for channelName, channel in asyncapi.channels() %}
+           {% if channel.publish() and channel.publish().hasTags() and channel.publish() | containTags(categorytags) %}
+            <a class="js-menu-item flex break-words no-underline text-grey-darkest mt-8 sm:mt-8 md:mt-3" href="#operation-publish-{{ channelName }}">
+              <span class="bg-blue-dark font-bold h-6 no-underline text-white uppercase p-1 mr-2 rounded" style="height: 21px;font-size: 11px;" title="Publish">
+                Pub
+              </span>
+              {% if channel.publish().summary() %}
+                <span style="padding-top: 2px;">
+                  {{ channel.publish().summary() }}
+                </span>
+              {% else %}
+                <div style="display:inline-block;">
+                  {{ slicedString(channelName, 'padding-top: 2px;') }}
+                </div>
+              {% endif %}
+            </a>
+          {% endif %}
+
+          {% if channel.subscribe() and channel.subscribe().hasTags() and channel.subscribe() | containTags(categorytags) %}
+            <a class="js-menu-item flex break-words no-underline text-grey-darkest mt-8 sm:mt-8 md:mt-3" href="#operation-subscribe-{{ channelName }}">
+              {% if channel.deprecated %}
+                <span title="Deprecated"></span>
+              {% endif %}
+              <span class="bg-green-dark font-bold no-underline text-white uppercase p-1 mr-2 rounded" style="height: 21px;font-size: 11px;" title="Subscribe">
+                Sub
+              </span>
+              {% if channel.subscribe().summary() %}
+                <span style="padding-top: 2px;">
+                  {{ channel.subscribe().summary() }}
+                </span>
+              {% else %}
+                <div style="display:inline-block;">
+                  {{ slicedString(channelName, 'padding-top: 2px;') }}
+                </div>
+              {% endif %}
+            </a>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </div>
+  {% endfor %}
+{% endif %}
+
+{% if asyncapi.channels() | containNoTag(asyncapi.tags()) %}
+  <!-- Untagged operations -->
+  <div class="mt-4 {% if open %}is-open{% endif %}">
+    <div class="js-prop cursor-pointer py-2 flex property">
+      <div class="pr-4" style="margin-top:-2px; min-width: 25%;">
+        <span class="text-sm" style="word-break: break-word;text-transform: capitalize;">
+          Untagged
+        </span>
+        <svg class="expand" version="1.1" viewBox="0 0 24 24" x="0" xmlns="http://www.w3.org/2000/svg" y="0">
+          <polygon points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "></polygon>
+        </svg>
+      </div>
+    </div>
+
+    <div class="children">
+      {% for channelName, channel in asyncapi.channels() %}
+        {% if channel.hasPublish() and (not channel.publish().hasTags() or not channel.publish() | containTags(asyncapi.tags())) %}
+          <a class="js-menu-item flex break-words no-underline text-grey-darkest mt-8 sm:mt-8 md:mt-3" href="#operation-publish-{{ channelName }}">
+            <span class="bg-blue-dark font-bold h-6 no-underline text-white uppercase p-1 mr-2 rounded" style="height: 21px;font-size: 11px;" title="Publish">
+              Pub
+            </span>
+            {% if channel.publish().summary() %}
+              <span style="padding-top: 2px;">
+                {{ channel.publish().summary() }}
+              </span>
+            {% else %}
+              <div style="display:inline-block;">
+                {{ slicedString(channelName, 'padding-top: 2px;') }}
+              </div>
+            {% endif %}
+          </a>
+        {% endif %}
+
+        {% if channel.hasSubscribe() and (not channel.subscribe().hasTags() or not channel.subscribe() | containTags(asyncapi.tags())) %}
+          <a class="js-menu-item flex break-words no-underline text-grey-darkest mt-8 sm:mt-8 md:mt-3" href="#operation-subscribe-{{ channelName }}">
+            <span class="bg-green-dark font-bold no-underline text-white uppercase p-1 mr-2 rounded" style="height: 21px;font-size: 11px;" title="Subscribe">
+              Sub
+            </span>
+            {% if channel.subscribe().summary() %}
+              <span style="padding-top: 2px;">
+                {{ channel.subscribe().summary() }}
+              </span>
+            {% else %}
+              <div style="display:inline-block;">
+                {{ slicedString(channelName, 'padding-top: 2px;') }}
+              </div>
+            {% endif %}
+          </a>
+        {% endif %}
+      {% endfor %}
+    </div>
+  </div>
+{% endif %}

--- a/partials/operations/by_tags_no_root.html
+++ b/partials/operations/by_tags_no_root.html
@@ -1,0 +1,108 @@
+{% for tag in asyncapi | operationsTags %}
+  <div class="mt-4 {% if open %}is-open{% endif %}">
+    <div class="js-prop cursor-pointer py-2 flex property">
+      <div class="pr-4" style="margin-top:-2px; min-width: 25%;">
+        <span class="text-sm" style="word-break: break-word;text-transform: capitalize;">
+          {{ tag }}
+        </span>
+        <svg class="expand" version="1.1" viewBox="0 0 24 24" x="0" xmlns="http://www.w3.org/2000/svg" y="0">
+          <polygon points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "></polygon>
+        </svg>
+      </div>
+    </div>
+
+    <div class="children">
+      {% for channelName, channel in asyncapi.channels() %}
+        {% if channel.publish() and channel.publish().hasTags() and channel.publish() | containTags(tag) %}
+          <a class="js-menu-item flex break-words no-underline text-grey-darkest mt-8 sm:mt-8 md:mt-3" href="#operation-publish-{{ channelName }}">
+            <span class="bg-blue-dark font-bold h-6 no-underline text-white uppercase p-1 mr-2 rounded" style="height: 21px;font-size: 11px;" title="Publish">
+              Pub
+            </span>
+            {% if channel.publish().summary() %}
+              <span style="padding-top: 2px;">
+                {{ channel.publish().summary() }}
+              </span>
+            {% else %}
+              <div style="display:inline-block;">
+                {{ slicedString(channelName, 'padding-top: 2px;') }}
+              </div>
+            {% endif %}
+          </a>
+        {% endif %}
+
+        {% if channel.subscribe() and channel.subscribe().hasTags() and channel.subscribe() | containTags(tag) %}
+          <a class="js-menu-item flex break-words no-underline text-grey-darkest mt-8 sm:mt-8 md:mt-3" href="#operation-subscribe-{{ channelName }}">
+            {% if channel.deprecated %}
+              <span title="Deprecated"></span>
+            {% endif %}
+            <span class="bg-green-dark font-bold no-underline text-white uppercase p-1 mr-2 rounded" style="height: 21px;font-size: 11px;" title="Subscribe">
+              Sub
+            </span>
+            {% if channel.subscribe().summary() %}
+              <span style="padding-top: 2px;">
+                {{ channel.subscribe().summary() }}
+              </span>
+            {% else %}
+              <div style="display:inline-block;">
+                {{ slicedString(channelName, 'padding-top: 2px;') }}
+              </div>
+            {% endif %}
+          </a>
+        {% endif %}
+      {% endfor %}
+    </div>
+  </div>
+{% endfor %}
+
+{% if asyncapi.channels() | containNoTag(asyncapi | operationsTags()) %}
+  <div class="mt-4 {% if open %}is-open{% endif %}">
+    <div class="js-prop cursor-pointer py-2 flex property">
+      <div class="pr-4" style="margin-top:-2px; min-width: 25%;">
+        <span class="text-sm" style="word-break: break-word;text-transform: capitalize;">
+          Untagged
+        </span>
+        <svg class="expand" version="1.1" viewBox="0 0 24 24" x="0" xmlns="http://www.w3.org/2000/svg" y="0">
+          <polygon points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "></polygon>
+        </svg>
+      </div>
+    </div>
+
+    <div class="children">
+      {% for channelName, channel in asyncapi.channels() %}
+        {% if channel.hasPublish() and (not channel.publish().hasTags() or not channel.publish() | containTags(asyncapi | operationsTags())) %}
+          <a class="js-menu-item flex break-words no-underline text-grey-darkest mt-8 sm:mt-8 md:mt-3" href="#operation-publish-{{ channelName }}">
+            <span class="bg-blue-dark font-bold h-6 no-underline text-white uppercase p-1 mr-2 rounded" style="height: 21px;font-size: 11px;" title="Publish">
+              Pub
+            </span>
+            {% if channel.publish().summary() %}
+              <span style="padding-top: 2px;">
+                {{ channel.publish().summary() }}
+              </span>
+            {% else %}
+              <div style="display:inline-block;">
+                {{ slicedString(channelName, 'padding-top: 2px;') }}
+              </div>
+            {% endif %}
+          </a>
+        {% endif %}
+
+        {% if channel.hasSubscribe() and (not channel.subscribe().hasTags() or not channel.subscribe() | containTags(asyncapi | operationsTags())) %}
+          <a class="js-menu-item flex break-words no-underline text-grey-darkest mt-8 sm:mt-8 md:mt-3" href="#operation-subscribe-{{ channelName }}">
+            <span class="bg-green-dark font-bold no-underline text-white uppercase p-1 mr-2 rounded" style="height: 21px;font-size: 11px;" title="Subscribe">
+              Sub
+            </span>
+            {% if channel.subscribe().summary() %}
+              <span style="padding-top: 2px;">
+                {{ channel.subscribe().summary() }}
+              </span>
+            {% else %}
+              <div style="display:inline-block;">
+                {{ slicedString(channelName, 'padding-top: 2px;') }}
+              </div>
+            {% endif %}
+          </a>
+        {% endif %}
+      {% endfor %}
+    </div>
+  </div>
+{% endif %}

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -8,185 +8,88 @@
     <span></span>
   </div>
 </label>
+
 <div class="sidebar-panel fixed pin-t pin-l pin-b w-64 bg-grey-lighter font-sans pt-8 pr-4 pb-4 pl-4">
   <div class="sidebar-panel__content">
     {% if asyncapi.info().ext('x-logo') %}
-    <img src="{{ asyncapi.info().ext('x-logo') }}" alt="{{ asyncapi.info().title() }} logo">
+      <img src="{{ asyncapi.info().ext('x-logo') }}" alt="{{ asyncapi.info().title() }} logo">
     {% else %}
-    <h1 class="text-2xl font-thin">{{ asyncapi.info().title() }} {{ asyncapi.info().version() }}</h1>
+      <h1 class="text-2xl font-thin">
+        {{ asyncapi.info().title() }} {{ asyncapi.info().version() }}
+      </h1>
     {% endif %}
     <ul class="text-sm mt-10 list-reset mt-2">
       <li class="mb-3">
         <a class="js-menu-item text-grey-darkest no-underline" href="#introduction">Introduction</a>
       </li>
       {% if asyncapi.servers %}
-      <li class="mb-3">
-        <a class="js-menu-item text-grey-darkest no-underline" href="#servers">Servers</a>
-      </li>
+        <li class="mb-3">
+          <a class="js-menu-item text-grey-darkest no-underline" href="#servers">Servers</a>
+        </li>
       {% endif %}
     </ul>
+
     {% if asyncapi.hasChannels() %}
-    <h2 class="text-xs uppercase text-grey mt-10 mb-4 font-thin">Operations</h2>
-    <ul class="text-sm list-reset mt-2">
-      {% if params.sidebarOrganization === 'byTags' %}
-      <!-- With tags in sidebar -->
-      {% if asyncapi.hasTags() %}
-      {% for categorytags in asyncapi.tags() %}
-      <div class="mt-4 {% if open %}is-open{% endif %}">
-        <div class="js-prop cursor-pointer py-2 flex property">
-          <div class="pr-4" style="margin-top:-2px; min-width: 25%;">
-            <span class="text-sm"
-              style="word-break: break-word;text-transform: capitalize;">{{ categorytags.name() }}</span>
-            <svg class="expand" version="1.1" viewBox="0 0 24 24" x="0" xmlns="http://www.w3.org/2000/svg" y="0">
-              <polygon points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "></polygon>
-            </svg>
-          </div>
-        </div>
-        <div class="children">
+      <h2 class="text-xs uppercase text-grey mt-10 mb-4 font-thin">Operations</h2>
+      <ul class="text-sm list-reset mt-2">
+        <!-- With tags in sidebar -->
+        {% if params.sidebarOrganization === 'byTags' %}
+          {% include "./operations/by_tags.html" %}
+        {% elif params.sidebarOrganization === 'byTagsNoRoot' %}
+          {% include "./operations/by_tags_no_root.html" %}
+        {% else %}
+          <!--Without tags in sidebar-->
           {% for channelName, channel in asyncapi.channels() %}
-             {% if channel.publish() and channel.publish().hasTags() and channel.publish() | containTags(categorytags) %}
-              <a class="js-menu-item flex break-words no-underline text-grey-darkest mt-8 sm:mt-8 md:mt-3"
-                href="#operation-publish-{{ channelName }}">
-                <span class="bg-blue-dark font-bold h-6 no-underline text-white uppercase p-1 mr-2 rounded"
-                  style="height: 21px;font-size: 11px;" title="Publish">Pub</span>
-                {% if channel.publish().summary() %}
-                <span style="padding-top: 2px;">
-                  {{ channel.publish().summary() }}
-                </span>
-                {% else %}
-                <div style="display:inline-block;">
-                  {{ slicedString(channelName, 'padding-top: 2px;') }}
-                </div>
-                {% endif %}
-              </a>
-            {% endif %}
-
-            {% if channel.subscribe() and channel.subscribe().hasTags() and channel.subscribe() | containTags(categorytags) %}
-            <a class="js-menu-item flex break-words no-underline text-grey-darkest mt-8 sm:mt-8 md:mt-3"
-              href="#operation-subscribe-{{ channelName }}">
-              {% if channel.deprecated %}<span title="Deprecated"></span>{% endif %}
-              <span class="bg-green-dark font-bold no-underline text-white uppercase p-1 mr-2 rounded"
-                style="height: 21px;font-size: 11px;" title="Subscribe">Sub</span>
-              {% if channel.subscribe().summary() %}
-              <span style="padding-top: 2px;">
-                {{ channel.subscribe().summary() }}
-              </span>
-              {% else %}
-              <div style="display:inline-block;">
-                {{ slicedString(channelName, 'padding-top: 2px;') }}
-              </div>
+            <li>
+              {% if channel.publish() %}
+                <a class="js-menu-item flex break-words no-underline text-grey-darkest mt-8 sm:mt-8 md:mt-3" href="#operation-publish-{{ channelName }}">
+                  <span class="bg-blue-dark font-bold h-6 no-underline text-white uppercase p-1 mr-2 rounded" style="height: 21px;font-size: 11px;" title="Publish">
+                    Pub
+                  </span>
+                  {% if channel.publish().summary() %}
+                    <span style="padding-top: 2px;">
+                      {{ channel.publish().summary() }}
+                    </span>
+                  {% else %}
+                    <div style="display:inline-block;">
+                      {{ slicedString(channelName, 'padding-top: 2px;') }}
+                    </div>
+                  {% endif %}
+                </a>
               {% endif %}
-            </a>
-            {% endif %}
+
+              {% if channel.subscribe() %}
+                <a class="js-menu-item flex break-words no-underline text-grey-darkest mt-8 sm:mt-8 md:mt-3" href="#operation-subscribe-{{ channelName }}">
+                  <span class="bg-green-dark font-bold no-underline text-white uppercase p-1 mr-2 rounded" style="height: 21px;font-size: 11px;" title="Subscribe">
+                    Sub
+                  </span>
+                  {% if channel.subscribe().summary() %}
+                    <span style="padding-top: 2px;">
+                      {{ channel.subscribe().summary() }}
+                    </span>
+                  {% else %}
+                    <div style="display:inline-block;">
+                      {{ slicedString(channelName, 'padding-top: 2px;') }}
+                    </div>
+                  {% endif %}
+                </a>
+              {% endif %}
+              </a>
+            </li>
           {% endfor %}
-        </div>
-      </div>
-      {% endfor %}
-      {% endif %}
-
-      {% if asyncapi.channels() | containNoTag(asyncapi.tags()) %}
-      <!-- Untagged operations -->
-      <div class="mt-4 {% if open %}is-open{% endif %}">
-        <div class="js-prop cursor-pointer py-2 flex property">
-          <div class="pr-4" style="margin-top:-2px; min-width: 25%;">
-            <span class="text-sm" style="word-break: break-word;text-transform: capitalize;">Untagged</span>
-            <svg class="expand" version="1.1" viewBox="0 0 24 24" x="0" xmlns="http://www.w3.org/2000/svg" y="0">
-              <polygon points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "></polygon>
-            </svg>
-          </div>
-        </div>
-        <div class="children">
-          {% for channelName, channel in asyncapi.channels() %}
-          {% if channel.hasPublish() and (not channel.publish().hasTags() or not channel.publish() | containTags(asyncapi.tags())) %}
-          <a class="js-menu-item flex break-words no-underline text-grey-darkest mt-8 sm:mt-8 md:mt-3"
-            href="#operation-publish-{{ channelName }}">
-            <span class="bg-blue-dark font-bold h-6 no-underline text-white uppercase p-1 mr-2 rounded"
-              style="height: 21px;font-size: 11px;" title="Publish">Pub</span>
-            {% if channel.publish().summary() %}
-            <span style="padding-top: 2px;">
-              {{ channel.publish().summary() }}
-            </span>
-            {% else %}
-            <div style="display:inline-block;">
-              {{ slicedString(channelName, 'padding-top: 2px;') }}
-            </div>
-            {% endif %}
-          </a>
-          {% endif %}
-          {% if channel.hasSubscribe() and (not channel.subscribe().hasTags() or not channel.subscribe() | containTags(asyncapi.tags())) %}
-          <a class="js-menu-item flex break-words no-underline text-grey-darkest mt-8 sm:mt-8 md:mt-3"
-            href="#operation-subscribe-{{ channelName }}">
-            <span class="bg-green-dark font-bold no-underline text-white uppercase p-1 mr-2 rounded"
-              style="height: 21px;font-size: 11px;" title="Subscribe">Sub</span>
-            {% if channel.subscribe().summary() %}
-            <span style="padding-top: 2px;">
-              {{ channel.subscribe().summary() }}
-            </span>
-            {% else %}
-            <div style="display:inline-block;">
-              {{ slicedString(channelName, 'padding-top: 2px;') }}
-            </div>
-            {% endif %}
-          </a>
-          {% endif %}
-          {% endfor %}
-        </div>
-      </div>
-      {% endif %}
-
-      {% else %}
-
-      <!--Without tags in sidebar-->
-      {% for channelName, channel in asyncapi.channels() %}
-      <li>
-        {% if channel.publish() %}
-        <a class="js-menu-item flex break-words no-underline text-grey-darkest mt-8 sm:mt-8 md:mt-3"
-          href="#operation-publish-{{ channelName }}">
-          <span class="bg-blue-dark font-bold h-6 no-underline text-white uppercase p-1 mr-2 rounded"
-            style="height: 21px;font-size: 11px;" title="Publish">Pub</span>
-          {% if channel.publish().summary() %}
-          <span style="padding-top: 2px;">
-            {{ channel.publish().summary() }}
-          </span>
-          {% else %}
-          <div style="display:inline-block;">
-            {{ slicedString(channelName, 'padding-top: 2px;') }}
-          </div>
-          {% endif %}
-        </a>
         {% endif %}
-        {% if channel.subscribe() %}
-        <a class="js-menu-item flex break-words no-underline text-grey-darkest mt-8 sm:mt-8 md:mt-3"
-          href="#operation-subscribe-{{ channelName }}">
-          <span class="bg-green-dark font-bold no-underline text-white uppercase p-1 mr-2 rounded"
-            style="height: 21px;font-size: 11px;" title="Subscribe">Sub</span>
-          {% if channel.subscribe().summary() %}
-          <span style="padding-top: 2px;">
-            {{ channel.subscribe().summary() }}
-          </span>
-          {% else %}
-          <div style="display:inline-block;">
-            {{ slicedString(channelName, 'padding-top: 2px;') }}
-          </div>
-          {% endif %}
-        </a>
-        {% endif %}
-        </a>
-      </li>
-      {% endfor %}
-    </ul>
-    {% endif %}
-    <h2 class="text-xs uppercase text-grey mt-10 mb-4 font-thin">Messages</h2>
-    <ul class="text-sm list-reset mt-2">
-      {% for key, value in asyncapi.allMessages() %}
-        <a class="js-menu-item flex break-words no-underline text-grey-darkest mt-8 sm:mt-8 md:mt-3"
-          href="#message-{{ key }}">
-          <div style="display:inline-block;">
-            {{ slicedString(key, 'padding-top: 2px;') }}
-          </div>
-        </a>
-      {% endfor %}
-    </ul>
+      </ul>
+
+      <h2 class="text-xs uppercase text-grey mt-10 mb-4 font-thin">Messages</h2>
+      <ul class="text-sm list-reset mt-2">
+        {% for key, value in asyncapi.allMessages() %}
+          <a class="js-menu-item flex break-words no-underline text-grey-darkest mt-8 sm:mt-8 md:mt-3" href="#message-{{ key }}">
+            <div style="display:inline-block;">
+              {{ slicedString(key, 'padding-top: 2px;') }}
+            </div>
+          </a>
+        {% endfor %}
+      </ul>
     {% endif %}
   </div>
 </div>

--- a/test/all.contain_no_tag.test.js
+++ b/test/all.contain_no_tag.test.js
@@ -58,3 +58,7 @@ test("returns true if none of the tags in channel.publish/subscribe match with t
   t.context.foobaz._json = t.context.foobaz;
   t.true(containNoTag([t.context.publish, t.context.subscribe], [t.context.foobar, t.context.foobaz]));
 });
+
+test("returns true when tagsToCheck is an array of strings and none of them matches", t => {
+  t.true(containNoTag([t.context.publish, t.context.subscribe], ["foobaz", "foobar"]));
+});

--- a/test/all.contain_tags.test.js
+++ b/test/all.contain_tags.test.js
@@ -48,3 +48,7 @@ test("returns true if at least one tag in the object matches with the given tags
 test("returns true when comparing tags even if tagsToCheck is a string", t => {
   t.true(containTags(t.context.doc, t.context.foo));
 });
+
+test("returns true when tagsToCheck is an array of strings and at least one of them matches", t => {
+  t.true(containTags(t.context.doc, [t.context.foo.name, "foobar"]));
+});

--- a/test/all.operations_tags.test.js
+++ b/test/all.operations_tags.test.js
@@ -1,0 +1,78 @@
+const test = require("ava");
+const {operationsTags} = require("../filters/all");
+
+const undef = undefined;
+
+test.beforeEach(t => {
+  t.context.parser = require("@asyncapi/parser");
+});
+
+test("it extracts the pub/sub tags names from the channel in the given object", t => {
+  const pubTags = [{ name: "smartylighting" }, { name: "measure" }];
+  const subTags = [{ name: "dim" }];
+  const input = {
+    channels: {
+      "smartylighting/streetlights/1/0/event/1/lighting/measured": {
+        publish: {
+          tags: pubTags
+        }
+      },
+      "smartylighting/streetlights/1/0/action/1/dim": {
+        subscribe: {
+          tags: subTags
+        }
+      }
+    }
+  };
+  const doc = new t.context.parser.AsyncAPIDocument(input);
+  const result = operationsTags(doc);
+
+  t.deepEqual(result, pubTags.concat(subTags).map(({ name }) => name ));
+  t.is(result.constructor.name, 'Array');
+});
+
+test("it extracts the pub/sub tags when present", t => {
+  const pubTags = [{ name: "smartylighting" }, { name: "measure" }];
+  const input = {
+    channels: {
+      "smartylighting/streetlights/1/0/event/1/lighting/measured": {
+        publish: {
+          tags: pubTags
+        }
+      },
+      "smartylighting/streetlights/1/0/action/1/dim": {
+        subscribe: {
+          operationId: "dim"
+        }
+      }
+    }
+  };
+  const doc = new t.context.parser.AsyncAPIDocument(input);
+  const result = operationsTags(doc);
+
+  t.deepEqual(result, pubTags.map(({ name }) => name ));
+  t.is(result.constructor.name, 'Array');
+});
+
+test("it extracts the pub/sub tags without repeated values", t => {
+  const subTags = pubTags = [{ name: "smartylighting" }];
+  const input = {
+    channels: {
+      "smartylighting/streetlights/1/0/event/1/lighting/measured": {
+        publish: {
+          tags: pubTags
+        }
+      },
+      "smartylighting/streetlights/1/0/action/1/dim": {
+        subscribe: {
+          operationId: subTags
+        }
+      }
+    }
+  };
+  const doc = new t.context.parser.AsyncAPIDocument(input);
+  const result = operationsTags(doc);
+
+  t.deepEqual(result, pubTags.map(({ name }) => name ));
+  t.is(result.constructor.name, 'Array');
+});

--- a/test/spec/asyncapi.yml
+++ b/test/spec/asyncapi.yml
@@ -39,20 +39,17 @@ channels:
       summary: Inform about environmental lighting conditions of a particular streetlight.
       operationId: receiveLightMeasurement
       tags:
-        - name: oparation-tag1
+        - name: operation-tag1
           externalDocs: 
             description: External docs description 1
             url: https://www.asyncapi.com/
-        - name: oparation-tag2
+        - name: operation-tag2
           description: Description 2
           externalDocs:
             url: "https://www.asyncapi.com/"
-        - name: oparation-tag3
-        - name: oparation-tag4
+        - name: operation-tag3
+        - name: operation-tag4
           description: Description 4
-        - name: message-tag5
-          externalDocs:  
-            url: "https://www.asyncapi.com/"
       traits:
         - $ref: '#/components/operationTraits/kafka'
       message:


### PR DESCRIPTION
Implements https://github.com/asyncapi/html-template/issues/42.

`all.js` now defines a function `operationsTags` to get subscription/publish operations tags and use them to build the sidebar.

New functionality available under `sidebarOrganization` param with `byTagsNoRoot` value