### PR TITLE
fix: Support for empty payload and mailto attribute for contact email

### DIFF
--- a/partials/introduction.html
+++ b/partials/introduction.html
@@ -25,7 +25,7 @@
       {% endif %}
       {% if asyncapi.info().contact().email() %}
       Contact email: <a class="border border-solid border-purple-lighter hover:bg-purple-lighter hover:text-purple-dark font-bold no-underline text-purple text-xs uppercase rounded mr-2 px-3 py-1"
-        href="{{asyncapi.info().contact().email()}}" target="_blank">{{asyncapi.info().contact().email()}}</a>
+        href="mailto:{{asyncapi.info().contact().email()}}" target="_blank">{{asyncapi.info().contact().email()}}</a>
       {% endif %}
     {% endif %}
   </div>

--- a/partials/message.html
+++ b/partials/message.html
@@ -20,7 +20,9 @@
   {{ tags(msg.tags()) }}
 
   <div class="mt-4 mb-4 markdown">{{ msg.description() | markdown2html | safe }}</div>
-  {{ schema(msg.payload(), 'Payload', open=open) }}
+  {% if msg.payload() %}
+    {{ schema(msg.payload(), 'Payload', open=open) }}
+  {% endif %}
   {% if msg.headers() %}
     <div class="mt-4">
       {{ schema(msg.headers(), 'Headers', open=open) }}


### PR DESCRIPTION
2 Birds, One stone!
This PR solves 2 issues
**Description**

Added mailto to the href for mail support as mentioned in issue #56
Wrapped msg.payload() within an if statement as in issue #55


Resolves #55 AND #56