### PR TITLE
fix: support node 12.2.0 when using singleFile parameter

### DIFF
--- a/hooks/01_removeNotRelevantParts.js
+++ b/hooks/01_removeNotRelevantParts.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const rimraf = require('rimraf');
 
 module.exports = {
     'generate:after': generator => {
@@ -18,8 +19,13 @@ module.exports = {
                 }
             };
 
-            fs.rmdir(jsDir, {recursive: true}, callback);
-            fs.rmdir(cssDir, {recursive: true}, callback);
+            const opts = {
+                disableGlob: true,
+                maxBusyTries: 3
+            };
+
+            rimraf(jsDir, opts, callback);
+            rimraf(cssDir, opts, callback);
         }
     }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
     },
     "@concordance/react": {
       "version": "2.0.0",
-      "resolved": "https://npm.fabit.ru/@concordance%2freact/-/react-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@concordance/react/-/react-2.0.0.tgz",
       "integrity": "sha512-huLSkUuM2/P+U0uy2WwlKuixMsTODD8p4JVQBI4VKeopkiN0C7M3N9XYVawb4M+4spN5RrO/eLhk7KoQX6nsfA==",
       "dev": true,
       "requires": {
@@ -462,13 +462,13 @@
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
-      "resolved": "https://npm.fabit.ru/@sindresorhus%2fis/-/is-0.14.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
-      "resolved": "https://npm.fabit.ru/@szmarczak%2fhttp-timer/-/http-timer-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
       "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
       "dev": true,
       "requires": {
@@ -551,7 +551,7 @@
     },
     "acorn-walk": {
       "version": "8.0.0",
-      "resolved": "https://npm.fabit.ru/acorn-walk/-/acorn-walk-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.0.0.tgz",
       "integrity": "sha512-oZRad/3SMOI/pxbbmqyurIx7jHw1wZDcR9G44L8pUVFEomX/0dH89SrM1KaDXuv1NpzAXz6Op/Xu/Qd5XXzdEA==",
       "dev": true
     },
@@ -588,7 +588,7 @@
     },
     "ansi-align": {
       "version": "3.0.0",
-      "resolved": "https://npm.fabit.ru/ansi-align/-/ansi-align-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
       "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
       "dev": true,
       "requires": {
@@ -597,25 +597,25 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://npm.fabit.ru/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "resolved": "https://npm.fabit.ru/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
           "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://npm.fabit.ru/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "https://npm.fabit.ru/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
@@ -626,7 +626,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://npm.fabit.ru/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
@@ -675,7 +675,7 @@
     },
     "anymatch": {
       "version": "3.1.1",
-      "resolved": "https://npm.fabit.ru/anymatch/-/anymatch-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
       "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
       "dev": true,
       "requires": {
@@ -699,7 +699,7 @@
     },
     "array-find-index": {
       "version": "1.0.2",
-      "resolved": "https://npm.fabit.ru/array-find-index/-/array-find-index-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
@@ -717,7 +717,7 @@
     },
     "arrgv": {
       "version": "1.0.2",
-      "resolved": "https://npm.fabit.ru/arrgv/-/arrgv-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/arrgv/-/arrgv-1.0.2.tgz",
       "integrity": "sha512-a4eg4yhp7mmruZDQFqVMlxNRFGi/i1r87pt8SDHy0/I8PqSXoUTlWZRdAZo0VXgvEARcujbtTk8kiZRi1uDGRw==",
       "dev": true
     },
@@ -729,7 +729,7 @@
     },
     "astral-regex": {
       "version": "2.0.0",
-      "resolved": "https://npm.fabit.ru/astral-regex/-/astral-regex-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
@@ -814,13 +814,13 @@
         },
         "arrify": {
           "version": "2.0.1",
-          "resolved": "https://npm.fabit.ru/arrify/-/arrify-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
           "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
           "dev": true
         },
         "chalk": {
           "version": "4.1.0",
-          "resolved": "https://npm.fabit.ru/chalk/-/chalk-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
           "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
@@ -830,7 +830,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://npm.fabit.ru/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -839,13 +839,13 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "https://npm.fabit.ru/color-name/-/color-name-1.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://npm.fabit.ru/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
@@ -857,7 +857,7 @@
         },
         "p-map": {
           "version": "4.0.0",
-          "resolved": "https://npm.fabit.ru/p-map/-/p-map-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
           "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
           "dev": true,
           "requires": {
@@ -866,7 +866,7 @@
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://npm.fabit.ru/supports-color/-/supports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
@@ -877,9 +877,8 @@
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://npm.fabit.ru/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "before-after-hook": {
       "version": "2.1.0",
@@ -889,13 +888,13 @@
     },
     "binary-extensions": {
       "version": "2.1.0",
-      "resolved": "https://npm.fabit.ru/binary-extensions/-/binary-extensions-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
     },
     "blueimp-md5": {
       "version": "2.18.0",
-      "resolved": "https://npm.fabit.ru/blueimp-md5/-/blueimp-md5-2.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.18.0.tgz",
       "integrity": "sha512-vE52okJvzsVWhcgUHOv+69OG3Mdg151xyn41aVQN/5W5S+S43qZhxECtYLAEHMSFWX6Mv5IZrzj3T5+JqXfj5Q==",
       "dev": true
     },
@@ -907,7 +906,7 @@
     },
     "boxen": {
       "version": "4.2.0",
-      "resolved": "https://npm.fabit.ru/boxen/-/boxen-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
       "integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
       "dev": true,
       "requires": {
@@ -933,7 +932,7 @@
         },
         "chalk": {
           "version": "3.0.0",
-          "resolved": "https://npm.fabit.ru/chalk/-/chalk-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
           "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
           "dev": true,
           "requires": {
@@ -943,7 +942,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://npm.fabit.ru/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -952,19 +951,19 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "https://npm.fabit.ru/color-name/-/color-name-1.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://npm.fabit.ru/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://npm.fabit.ru/supports-color/-/supports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
@@ -973,7 +972,7 @@
         },
         "type-fest": {
           "version": "0.8.1",
-          "resolved": "https://npm.fabit.ru/type-fest/-/type-fest-0.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
           "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
           "dev": true
         }
@@ -981,9 +980,8 @@
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://npm.fabit.ru/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1000,13 +998,13 @@
     },
     "buffer-from": {
       "version": "1.1.1",
-      "resolved": "https://npm.fabit.ru/buffer-from/-/buffer-from-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
     "cacheable-request": {
       "version": "6.1.0",
-      "resolved": "https://npm.fabit.ru/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
       "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
       "dev": true,
       "requires": {
@@ -1021,7 +1019,7 @@
       "dependencies": {
         "get-stream": {
           "version": "5.2.0",
-          "resolved": "https://npm.fabit.ru/get-stream/-/get-stream-5.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
           "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "dev": true,
           "requires": {
@@ -1030,13 +1028,13 @@
         },
         "lowercase-keys": {
           "version": "2.0.0",
-          "resolved": "https://npm.fabit.ru/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
           "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
           "dev": true
         },
         "normalize-url": {
           "version": "4.5.0",
-          "resolved": "https://npm.fabit.ru/normalize-url/-/normalize-url-4.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
           "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
           "dev": true
         }
@@ -1094,7 +1092,7 @@
     },
     "chokidar": {
       "version": "3.4.2",
-      "resolved": "https://npm.fabit.ru/chokidar/-/chokidar-3.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
       "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
       "dev": true,
       "requires": {
@@ -1110,19 +1108,19 @@
     },
     "chunkd": {
       "version": "2.0.1",
-      "resolved": "https://npm.fabit.ru/chunkd/-/chunkd-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/chunkd/-/chunkd-2.0.1.tgz",
       "integrity": "sha512-7d58XsFmOq0j6el67Ug9mHf9ELUXsQXYJBkyxhH/k+6Ke0qXRnv0kbemx+Twc6fRJ07C49lcbdgm9FL1Ei/6SQ==",
       "dev": true
     },
     "ci-info": {
       "version": "2.0.0",
-      "resolved": "https://npm.fabit.ru/ci-info/-/ci-info-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
     },
     "ci-parallel-vars": {
       "version": "1.0.1",
-      "resolved": "https://npm.fabit.ru/ci-parallel-vars/-/ci-parallel-vars-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ci-parallel-vars/-/ci-parallel-vars-1.0.1.tgz",
       "integrity": "sha512-uvzpYrpmidaoxvIQHM+rKSrigjOe9feHYbw4uOI2gdfe1C3xIlxO+kVXq83WQWNniTf8bAxVpy+cQeFQsMERKg==",
       "dev": true
     },
@@ -1134,19 +1132,19 @@
     },
     "clean-yaml-object": {
       "version": "0.1.0",
-      "resolved": "https://npm.fabit.ru/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
       "integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=",
       "dev": true
     },
     "cli-boxes": {
       "version": "2.2.1",
-      "resolved": "https://npm.fabit.ru/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
       "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
       "dev": true
     },
     "cli-cursor": {
       "version": "3.1.0",
-      "resolved": "https://npm.fabit.ru/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dev": true,
       "requires": {
@@ -1155,7 +1153,7 @@
     },
     "cli-spinners": {
       "version": "2.4.0",
-      "resolved": "https://npm.fabit.ru/cli-spinners/-/cli-spinners-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.4.0.tgz",
       "integrity": "sha512-sJAofoarcm76ZGpuooaO0eDy8saEy+YoZBLjC4h8srt4jeBnkYeOgqxgsJQTpyt2LjI5PTfLJHSL+41Yu4fEJA==",
       "dev": true
     },
@@ -1170,7 +1168,7 @@
     },
     "cli-truncate": {
       "version": "2.1.0",
-      "resolved": "https://npm.fabit.ru/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
       "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
       "dev": true,
       "requires": {
@@ -1191,13 +1189,13 @@
     },
     "clone": {
       "version": "1.0.4",
-      "resolved": "https://npm.fabit.ru/clone/-/clone-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
     },
     "clone-response": {
       "version": "1.0.2",
-      "resolved": "https://npm.fabit.ru/clone-response/-/clone-response-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "dev": true,
       "requires": {
@@ -1212,7 +1210,7 @@
     },
     "code-excerpt": {
       "version": "3.0.0",
-      "resolved": "https://npm.fabit.ru/code-excerpt/-/code-excerpt-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-3.0.0.tgz",
       "integrity": "sha512-VHNTVhd7KsLGOqfX3SyeO8RyYPMp1GJOg194VITk04WMYCv4plV68YWe6TJZxd9MhobjtpMRnVky01gqZsalaw==",
       "dev": true,
       "requires": {
@@ -1242,7 +1240,7 @@
     },
     "common-path-prefix": {
       "version": "3.0.0",
-      "resolved": "https://npm.fabit.ru/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
       "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
       "dev": true
     },
@@ -1258,13 +1256,12 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://npm.fabit.ru/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concordance": {
       "version": "5.0.1",
-      "resolved": "https://npm.fabit.ru/concordance/-/concordance-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concordance/-/concordance-5.0.1.tgz",
       "integrity": "sha512-TbNtInKVElgEBnJ1v2Xg+MFX2lvFLbmlv3EuSC5wTfCwpB8kC3w3mffF6cKuUhkn475Ym1f1I4qmuXzx2+uXpw==",
       "dev": true,
       "requires": {
@@ -1280,7 +1277,7 @@
       "dependencies": {
         "semver": {
           "version": "7.3.2",
-          "resolved": "https://npm.fabit.ru/semver/-/semver-7.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
         }
@@ -1288,7 +1285,7 @@
     },
     "configstore": {
       "version": "5.0.1",
-      "resolved": "https://npm.fabit.ru/configstore/-/configstore-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
       "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
       "dev": true,
       "requires": {
@@ -1374,7 +1371,7 @@
     },
     "convert-source-map": {
       "version": "1.7.0",
-      "resolved": "https://npm.fabit.ru/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
       "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
       "dev": true,
       "requires": {
@@ -1383,7 +1380,7 @@
     },
     "convert-to-spaces": {
       "version": "1.0.2",
-      "resolved": "https://npm.fabit.ru/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz",
       "integrity": "sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU=",
       "dev": true
     },
@@ -1427,7 +1424,7 @@
     },
     "currently-unhandled": {
       "version": "0.4.1",
-      "resolved": "https://npm.fabit.ru/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
@@ -1436,7 +1433,7 @@
     },
     "date-time": {
       "version": "3.1.0",
-      "resolved": "https://npm.fabit.ru/date-time/-/date-time-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/date-time/-/date-time-3.1.0.tgz",
       "integrity": "sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==",
       "dev": true,
       "requires": {
@@ -1484,7 +1481,7 @@
     },
     "decompress-response": {
       "version": "3.3.0",
-      "resolved": "https://npm.fabit.ru/decompress-response/-/decompress-response-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
       "requires": {
@@ -1499,7 +1496,7 @@
     },
     "defaults": {
       "version": "1.0.3",
-      "resolved": "https://npm.fabit.ru/defaults/-/defaults-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
@@ -1508,7 +1505,7 @@
     },
     "defer-to-connect": {
       "version": "1.1.3",
-      "resolved": "https://npm.fabit.ru/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
       "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
       "dev": true
     },
@@ -1590,13 +1587,13 @@
     },
     "duplexer3": {
       "version": "0.1.4",
-      "resolved": "https://npm.fabit.ru/duplexer3/-/duplexer3-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
     },
     "emittery": {
       "version": "0.7.1",
-      "resolved": "https://npm.fabit.ru/emittery/-/emittery-0.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.1.tgz",
       "integrity": "sha512-d34LN4L6h18Bzz9xpoku2nPwKxCPlPMr3EEKTkoEBi+1/+b0lcRkRJ1UVyyZaKNeqGR3swcGl6s390DNO4YVgQ==",
       "dev": true
     },
@@ -1716,7 +1713,7 @@
     },
     "equal-length": {
       "version": "1.0.1",
-      "resolved": "https://npm.fabit.ru/equal-length/-/equal-length-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/equal-length/-/equal-length-1.0.1.tgz",
       "integrity": "sha1-IcoRLUirJLTh5//A5TOdMf38J0w=",
       "dev": true
     },
@@ -1731,7 +1728,7 @@
     },
     "escape-goat": {
       "version": "2.1.1",
-      "resolved": "https://npm.fabit.ru/escape-goat/-/escape-goat-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
       "integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
       "dev": true
     },
@@ -1749,7 +1746,7 @@
     },
     "esutils": {
       "version": "2.0.3",
-      "resolved": "https://npm.fabit.ru/esutils/-/esutils-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
@@ -1776,7 +1773,7 @@
     },
     "fast-diff": {
       "version": "1.2.0",
-      "resolved": "https://npm.fabit.ru/fast-diff/-/fast-diff-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
@@ -1875,9 +1872,8 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://npm.fabit.ru/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.1.3",
@@ -1938,9 +1934,8 @@
     },
     "glob": {
       "version": "7.1.6",
-      "resolved": "https://npm.fabit.ru/glob/-/glob-7.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1961,7 +1956,7 @@
     },
     "global-dirs": {
       "version": "2.0.1",
-      "resolved": "https://npm.fabit.ru/global-dirs/-/global-dirs-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
       "integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
       "dev": true,
       "requires": {
@@ -1984,7 +1979,7 @@
     },
     "got": {
       "version": "9.6.0",
-      "resolved": "https://npm.fabit.ru/got/-/got-9.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
       "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
       "dev": true,
       "requires": {
@@ -2040,7 +2035,7 @@
     },
     "has-yarn": {
       "version": "2.1.0",
-      "resolved": "https://npm.fabit.ru/has-yarn/-/has-yarn-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
       "dev": true
     },
@@ -2058,7 +2053,7 @@
     },
     "http-cache-semantics": {
       "version": "4.1.0",
-      "resolved": "https://npm.fabit.ru/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
       "dev": true
     },
@@ -2097,7 +2092,7 @@
     },
     "ignore-by-default": {
       "version": "2.0.0",
-      "resolved": "https://npm.fabit.ru/ignore-by-default/-/ignore-by-default-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-2.0.0.tgz",
       "integrity": "sha512-+mQSgMRiFD3L3AOxLYOCxjIq4OnAmo5CIuC+lj5ehCJcPtV++QacEV7FdpzvYxH6DaOySWzQU6RR0lPLy37ckA==",
       "dev": true
     },
@@ -2130,13 +2125,13 @@
     },
     "import-lazy": {
       "version": "2.1.0",
-      "resolved": "https://npm.fabit.ru/import-lazy/-/import-lazy-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
       "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
       "dev": true
     },
     "import-local": {
       "version": "3.0.2",
-      "resolved": "https://npm.fabit.ru/import-local/-/import-local-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
       "integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
       "dev": true,
       "requires": {
@@ -2146,7 +2141,7 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://npm.fabit.ru/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
@@ -2158,9 +2153,8 @@
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://npm.fabit.ru/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -2169,8 +2163,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://npm.fabit.ru/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.5",
@@ -2190,7 +2183,7 @@
     },
     "irregular-plurals": {
       "version": "3.2.0",
-      "resolved": "https://npm.fabit.ru/irregular-plurals/-/irregular-plurals-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.2.0.tgz",
       "integrity": "sha512-YqTdPLfwP7YFN0SsD3QUVCkm9ZG2VzOXv3DOrw5G5mkMbVwptTwVcFv7/C0vOpBmgTxAeTG19XpUs1E522LW9Q==",
       "dev": true
     },
@@ -2202,7 +2195,7 @@
     },
     "is-binary-path": {
       "version": "2.1.0",
-      "resolved": "https://npm.fabit.ru/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
       "requires": {
@@ -2211,7 +2204,7 @@
     },
     "is-ci": {
       "version": "2.0.0",
-      "resolved": "https://npm.fabit.ru/is-ci/-/is-ci-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
       "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
       "dev": true,
       "requires": {
@@ -2220,7 +2213,7 @@
     },
     "is-error": {
       "version": "2.2.2",
-      "resolved": "https://npm.fabit.ru/is-error/-/is-error-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.2.tgz",
       "integrity": "sha512-IOQqts/aHWbiisY5DuPJQ0gcbvaLFCa7fBa9xoLfxBZvQ+ZI/Zh9xoI7Gk+G64N0FdK4AbibytHht2tWgpJWLg==",
       "dev": true
     },
@@ -2247,7 +2240,7 @@
     },
     "is-installed-globally": {
       "version": "0.3.2",
-      "resolved": "https://npm.fabit.ru/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
       "integrity": "sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==",
       "dev": true,
       "requires": {
@@ -2257,13 +2250,13 @@
     },
     "is-interactive": {
       "version": "1.0.0",
-      "resolved": "https://npm.fabit.ru/is-interactive/-/is-interactive-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
       "dev": true
     },
     "is-npm": {
       "version": "4.0.0",
-      "resolved": "https://npm.fabit.ru/is-npm/-/is-npm-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-4.0.0.tgz",
       "integrity": "sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==",
       "dev": true
     },
@@ -2281,13 +2274,13 @@
     },
     "is-path-cwd": {
       "version": "2.2.0",
-      "resolved": "https://npm.fabit.ru/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
       "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
       "dev": true
     },
     "is-path-inside": {
       "version": "3.0.2",
-      "resolved": "https://npm.fabit.ru/is-path-inside/-/is-path-inside-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
       "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
       "dev": true
     },
@@ -2305,7 +2298,7 @@
     },
     "is-promise": {
       "version": "4.0.0",
-      "resolved": "https://npm.fabit.ru/is-promise/-/is-promise-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "dev": true
     },
@@ -2326,13 +2319,13 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://npm.fabit.ru/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "is-yarn-global": {
       "version": "0.3.0",
-      "resolved": "https://npm.fabit.ru/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
       "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
       "dev": true
     },
@@ -2369,7 +2362,7 @@
     },
     "js-string-escape": {
       "version": "1.0.1",
-      "resolved": "https://npm.fabit.ru/js-string-escape/-/js-string-escape-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
       "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=",
       "dev": true
     },
@@ -2391,7 +2384,7 @@
     },
     "json-buffer": {
       "version": "3.0.0",
-      "resolved": "https://npm.fabit.ru/json-buffer/-/json-buffer-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
       "dev": true
     },
@@ -2455,7 +2448,7 @@
     },
     "keyv": {
       "version": "3.1.0",
-      "resolved": "https://npm.fabit.ru/keyv/-/keyv-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
       "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
       "dev": true,
       "requires": {
@@ -2470,7 +2463,7 @@
     },
     "latest-version": {
       "version": "5.1.0",
-      "resolved": "https://npm.fabit.ru/latest-version/-/latest-version-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
       "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
       "dev": true,
       "requires": {
@@ -2493,7 +2486,7 @@
     },
     "load-json-file": {
       "version": "5.3.0",
-      "resolved": "https://npm.fabit.ru/load-json-file/-/load-json-file-5.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
       "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
       "dev": true,
       "requires": {
@@ -2506,7 +2499,7 @@
       "dependencies": {
         "parse-json": {
           "version": "4.0.0",
-          "resolved": "https://npm.fabit.ru/parse-json/-/parse-json-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
@@ -2516,7 +2509,7 @@
         },
         "type-fest": {
           "version": "0.3.1",
-          "resolved": "https://npm.fabit.ru/type-fest/-/type-fest-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
           "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
           "dev": true
         }
@@ -2580,7 +2573,7 @@
     },
     "log-symbols": {
       "version": "4.0.0",
-      "resolved": "https://npm.fabit.ru/log-symbols/-/log-symbols-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
       "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
       "dev": true,
       "requires": {
@@ -2599,7 +2592,7 @@
         },
         "chalk": {
           "version": "4.1.0",
-          "resolved": "https://npm.fabit.ru/chalk/-/chalk-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
           "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
@@ -2609,7 +2602,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://npm.fabit.ru/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -2618,19 +2611,19 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "https://npm.fabit.ru/color-name/-/color-name-1.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://npm.fabit.ru/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://npm.fabit.ru/supports-color/-/supports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
@@ -2641,7 +2634,7 @@
     },
     "lowercase-keys": {
       "version": "1.0.1",
-      "resolved": "https://npm.fabit.ru/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
     },
@@ -2662,7 +2655,7 @@
     },
     "make-dir": {
       "version": "3.1.0",
-      "resolved": "https://npm.fabit.ru/make-dir/-/make-dir-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "dev": true,
       "requires": {
@@ -2671,7 +2664,7 @@
       "dependencies": {
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://npm.fabit.ru/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
@@ -2679,7 +2672,7 @@
     },
     "map-age-cleaner": {
       "version": "0.1.3",
-      "resolved": "https://npm.fabit.ru/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
       "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
       "dev": true,
       "requires": {
@@ -2778,7 +2771,7 @@
     },
     "matcher": {
       "version": "3.0.0",
-      "resolved": "https://npm.fabit.ru/matcher/-/matcher-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
       "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
       "dev": true,
       "requires": {
@@ -2787,7 +2780,7 @@
       "dependencies": {
         "escape-string-regexp": {
           "version": "4.0.0",
-          "resolved": "https://npm.fabit.ru/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
           "dev": true
         }
@@ -2795,7 +2788,7 @@
     },
     "md5-hex": {
       "version": "3.0.1",
-      "resolved": "https://npm.fabit.ru/md5-hex/-/md5-hex-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-3.0.1.tgz",
       "integrity": "sha512-BUiRtTtV39LIJwinWBjqVsU9xhdnz7/i889V859IBFpuqGAj6LuOvHv5XLbgZ2R7ptJoJaEcxkv88/h25T7Ciw==",
       "dev": true,
       "requires": {
@@ -2809,7 +2802,7 @@
     },
     "mem": {
       "version": "6.1.1",
-      "resolved": "https://npm.fabit.ru/mem/-/mem-6.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-6.1.1.tgz",
       "integrity": "sha512-Ci6bIfq/UgcxPTYa8dQQ5FY3BzKkT894bwXWXxC/zqs0XgMO2cT20CGkOqda7gZNkmK5VP4x89IGZ6K7hfbn3Q==",
       "dev": true,
       "requires": {
@@ -2819,7 +2812,7 @@
       "dependencies": {
         "mimic-fn": {
           "version": "3.1.0",
-          "resolved": "https://npm.fabit.ru/mimic-fn/-/mimic-fn-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
           "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
           "dev": true
         }
@@ -2880,7 +2873,7 @@
     },
     "mimic-response": {
       "version": "1.0.1",
-      "resolved": "https://npm.fabit.ru/mimic-response/-/mimic-response-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true
     },
@@ -2892,9 +2885,8 @@
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "https://npm.fabit.ru/minimatch/-/minimatch-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -2930,7 +2922,7 @@
     },
     "mute-stream": {
       "version": "0.0.8",
-      "resolved": "https://npm.fabit.ru/mute-stream/-/mute-stream-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
@@ -2981,7 +2973,7 @@
     },
     "normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://npm.fabit.ru/normalize-path/-/normalize-path-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
@@ -6521,7 +6513,6 @@
       "version": "1.4.0",
       "resolved": "https://npm.fabit.ru/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -6545,7 +6536,7 @@
     },
     "ora": {
       "version": "5.1.0",
-      "resolved": "https://npm.fabit.ru/ora/-/ora-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.1.0.tgz",
       "integrity": "sha512-9tXIMPvjZ7hPTbk8DFq1f7Kow/HU/pQYB60JbNq+QnGwcyhWVZaQ4hM9zQDEsPxw/muLpgiHSaumUZxCAmod/w==",
       "dev": true,
       "requires": {
@@ -6571,7 +6562,7 @@
         },
         "chalk": {
           "version": "4.1.0",
-          "resolved": "https://npm.fabit.ru/chalk/-/chalk-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
           "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
@@ -6581,7 +6572,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://npm.fabit.ru/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -6590,19 +6581,19 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "https://npm.fabit.ru/color-name/-/color-name-1.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://npm.fabit.ru/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://npm.fabit.ru/supports-color/-/supports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
@@ -6623,13 +6614,13 @@
     },
     "p-cancelable": {
       "version": "1.1.0",
-      "resolved": "https://npm.fabit.ru/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
       "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
       "dev": true
     },
     "p-defer": {
       "version": "1.0.0",
-      "resolved": "https://npm.fabit.ru/p-defer/-/p-defer-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
       "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
       "dev": true
     },
@@ -6708,7 +6699,7 @@
     },
     "package-json": {
       "version": "6.5.0",
-      "resolved": "https://npm.fabit.ru/package-json/-/package-json-6.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
       "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
       "dev": true,
       "requires": {
@@ -6720,7 +6711,7 @@
       "dependencies": {
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://npm.fabit.ru/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
@@ -6749,7 +6740,7 @@
     },
     "parse-ms": {
       "version": "2.1.0",
-      "resolved": "https://npm.fabit.ru/parse-ms/-/parse-ms-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
       "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
       "dev": true
     },
@@ -6761,9 +6752,8 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://npm.fabit.ru/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "2.0.1",
@@ -6791,13 +6781,13 @@
     },
     "pify": {
       "version": "4.0.1",
-      "resolved": "https://npm.fabit.ru/pify/-/pify-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true
     },
     "pkg-conf": {
       "version": "3.1.0",
-      "resolved": "https://npm.fabit.ru/pkg-conf/-/pkg-conf-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
       "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
       "dev": true,
       "requires": {
@@ -6807,7 +6797,7 @@
       "dependencies": {
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://npm.fabit.ru/find-up/-/find-up-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
@@ -6816,7 +6806,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://npm.fabit.ru/locate-path/-/locate-path-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
@@ -6826,7 +6816,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://npm.fabit.ru/p-locate/-/p-locate-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
@@ -6835,7 +6825,7 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://npm.fabit.ru/path-exists/-/path-exists-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         }
@@ -6843,7 +6833,7 @@
     },
     "pkg-dir": {
       "version": "4.2.0",
-      "resolved": "https://npm.fabit.ru/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "dev": true,
       "requires": {
@@ -6852,7 +6842,7 @@
     },
     "plur": {
       "version": "4.0.0",
-      "resolved": "https://npm.fabit.ru/plur/-/plur-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
       "integrity": "sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==",
       "dev": true,
       "requires": {
@@ -6861,7 +6851,7 @@
     },
     "prepend-http": {
       "version": "2.0.0",
-      "resolved": "https://npm.fabit.ru/prepend-http/-/prepend-http-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
       "dev": true
     },
@@ -6898,7 +6888,7 @@
     },
     "pupa": {
       "version": "2.0.1",
-      "resolved": "https://npm.fabit.ru/pupa/-/pupa-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.0.1.tgz",
       "integrity": "sha512-hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==",
       "dev": true,
       "requires": {
@@ -6985,7 +6975,7 @@
     },
     "readdirp": {
       "version": "3.4.0",
-      "resolved": "https://npm.fabit.ru/readdirp/-/readdirp-3.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
       "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
       "dev": true,
       "requires": {
@@ -7022,7 +7012,7 @@
     },
     "registry-url": {
       "version": "5.1.0",
-      "resolved": "https://npm.fabit.ru/registry-url/-/registry-url-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
       "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
       "dev": true,
       "requires": {
@@ -7052,7 +7042,7 @@
     },
     "resolve-cwd": {
       "version": "3.0.0",
-      "resolved": "https://npm.fabit.ru/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
       "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
       "dev": true,
       "requires": {
@@ -7067,7 +7057,7 @@
     },
     "responselike": {
       "version": "1.0.2",
-      "resolved": "https://npm.fabit.ru/responselike/-/responselike-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "dev": true,
       "requires": {
@@ -7076,7 +7066,7 @@
     },
     "restore-cursor": {
       "version": "3.1.0",
-      "resolved": "https://npm.fabit.ru/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
       "requires": {
@@ -7098,9 +7088,8 @@
     },
     "rimraf": {
       "version": "3.0.2",
-      "resolved": "https://npm.fabit.ru/rimraf/-/rimraf-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -7283,7 +7272,7 @@
     },
     "serialize-error": {
       "version": "2.1.0",
-      "resolved": "https://npm.fabit.ru/serialize-error/-/serialize-error-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
       "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go=",
       "dev": true
     },
@@ -7431,7 +7420,7 @@
     },
     "slice-ansi": {
       "version": "3.0.0",
-      "resolved": "https://npm.fabit.ru/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
       "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
       "dev": true,
       "requires": {
@@ -7452,7 +7441,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://npm.fabit.ru/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -7461,7 +7450,7 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "https://npm.fabit.ru/color-name/-/color-name-1.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         }
@@ -7475,7 +7464,7 @@
     },
     "source-map-support": {
       "version": "0.5.19",
-      "resolved": "https://npm.fabit.ru/source-map-support/-/source-map-support-0.5.19.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
       "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
       "dev": true,
       "requires": {
@@ -7558,7 +7547,7 @@
     },
     "stack-utils": {
       "version": "2.0.2",
-      "resolved": "https://npm.fabit.ru/stack-utils/-/stack-utils-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.2.tgz",
       "integrity": "sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==",
       "dev": true,
       "requires": {
@@ -7567,7 +7556,7 @@
       "dependencies": {
         "escape-string-regexp": {
           "version": "2.0.0",
-          "resolved": "https://npm.fabit.ru/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
           "dev": true
         }
@@ -7647,7 +7636,7 @@
     },
     "supertap": {
       "version": "1.0.0",
-      "resolved": "https://npm.fabit.ru/supertap/-/supertap-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/supertap/-/supertap-1.0.0.tgz",
       "integrity": "sha512-HZJ3geIMPgVwKk2VsmO5YHqnnJYl6bV5A9JW2uzqV43WmpgliNEYbuvukfor7URpaqpxuw3CfZ3ONdVbZjCgIA==",
       "dev": true,
       "requires": {
@@ -7660,19 +7649,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://npm.fabit.ru/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "indent-string": {
           "version": "3.2.0",
-          "resolved": "https://npm.fabit.ru/indent-string/-/indent-string-3.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
           "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
           "dev": true
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://npm.fabit.ru/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -7751,7 +7740,7 @@
     },
     "term-size": {
       "version": "2.2.0",
-      "resolved": "https://npm.fabit.ru/term-size/-/term-size-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.0.tgz",
       "integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw==",
       "dev": true
     },
@@ -7779,7 +7768,7 @@
     },
     "time-zone": {
       "version": "1.0.0",
-      "resolved": "https://npm.fabit.ru/time-zone/-/time-zone-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
       "integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
       "dev": true
     },
@@ -7791,7 +7780,7 @@
     },
     "to-readable-stream": {
       "version": "1.0.0",
-      "resolved": "https://npm.fabit.ru/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
       "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
       "dev": true
     },
@@ -7830,7 +7819,7 @@
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
-      "resolved": "https://npm.fabit.ru/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dev": true,
       "requires": {
@@ -7906,7 +7895,7 @@
         },
         "chalk": {
           "version": "3.0.0",
-          "resolved": "https://npm.fabit.ru/chalk/-/chalk-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
           "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
           "dev": true,
           "requires": {
@@ -7916,7 +7905,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://npm.fabit.ru/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -7925,19 +7914,19 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "https://npm.fabit.ru/color-name/-/color-name-1.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://npm.fabit.ru/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://npm.fabit.ru/supports-color/-/supports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
@@ -7963,7 +7952,7 @@
     },
     "url-parse-lax": {
       "version": "3.0.0",
-      "resolved": "https://npm.fabit.ru/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
       "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
       "dev": true,
       "requires": {
@@ -7988,7 +7977,7 @@
     },
     "wcwidth": {
       "version": "1.0.1",
-      "resolved": "https://npm.fabit.ru/wcwidth/-/wcwidth-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "dev": true,
       "requires": {
@@ -7997,7 +7986,7 @@
     },
     "well-known-symbols": {
       "version": "2.0.0",
-      "resolved": "https://npm.fabit.ru/well-known-symbols/-/well-known-symbols-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-2.0.0.tgz",
       "integrity": "sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==",
       "dev": true
     },
@@ -8018,7 +8007,7 @@
     },
     "widest-line": {
       "version": "3.1.0",
-      "resolved": "https://npm.fabit.ru/widest-line/-/widest-line-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
       "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
       "dev": true,
       "requires": {
@@ -8081,12 +8070,11 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://npm.fabit.ru/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "3.0.3",
-      "resolved": "https://npm.fabit.ru/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
       "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
       "dev": true,
       "requires": {
@@ -8098,7 +8086,7 @@
     },
     "xdg-basedir": {
       "version": "4.0.0",
-      "resolved": "https://npm.fabit.ru/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@asyncapi/generator-filters": "^1.1.0"
+    "@asyncapi/generator-filters": "^1.1.0",
+    "rimraf": "^3.0.2"
   },
   "devDependencies": {
     "@asyncapi/parser": "^0.27.0",


### PR DESCRIPTION
**Description**
Pulls in `rimraf` module which is a stable recursive directory delete that can replace `fs.rmdir` until it becomes stable.

**Related issue(s)**
Resolves #78 