### PR TITLE
fix: Default to Authorization header when auth type is http

### DIFF
--- a/partials/servers.html
+++ b/partials/servers.html
@@ -106,7 +106,7 @@
 
               {% if def.bearerFormat() %}
                 <span class="font-bold no-underline bg-blue-light text-white text-xs uppercase rounded"
-                  style="height: 20px;font-size: 11px;padding: 3px;">Header: {{'Authorization' if def.type() === 'http' else def.name()}}
+                  style="height: 20px;font-size: 11px;padding: 3px;">Header: Authorization
                 </span>
               {% endif %}
 

--- a/partials/servers.html
+++ b/partials/servers.html
@@ -106,7 +106,8 @@
 
               {% if def.bearerFormat() %}
                 <span class="font-bold no-underline bg-blue-light text-white text-xs uppercase rounded"
-                  style="height: 20px;font-size: 11px;padding: 3px;">Header: {{def.name()}}</span>
+                  style="height: 20px;font-size: 11px;padding: 3px;">Header: {{'Authorization' if def.type() === 'http' else def.name()}}
+                </span>
               {% endif %}
 
               {% if def.openIdConnectUrl() %}

--- a/test/spec/asyncapi.yml
+++ b/test/spec/asyncapi.yml
@@ -26,6 +26,8 @@ servers:
         enum:
           - '1883'
           - '8883'
+    security:
+      - bearerAuth: []
 
 defaultContentType: application/json
 
@@ -171,6 +173,11 @@ components:
       description: Date and time when the message was sent.
 
   securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: The JWT for authorizing against the backend. Needs to be obtained through the authentication route.
     apiKey:
       type: apiKey
       in: user


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Default to Authorization when auth type is http.

**Related issue(s)**
Fixes #28

![Captura de pantalla de 2020-10-08 13-14-58](https://user-images.githubusercontent.com/6112820/95451633-5c04cf80-0968-11eb-9bd9-5fdd6faff690.png)
