### PR TITLE
feat: display schema uid and broken support for oneOf anyOf allOf in array items

### DIFF
--- a/partials/schema-prop.html
+++ b/partials/schema-prop.html
@@ -149,18 +149,19 @@
 
         {% if prop.type() === 'array' %}
           {% set arrayItemsProps = (prop.items().properties() if prop.items() else null) %}
-          {% if prop.items() and not arrayItemsProps %}
+          {% if prop.items() and arrayItemsProps | isEmpty %}
             <p class="pl-6 mb-2 text-xs font-bold uppercase text-grey-darker">Items:</p>
             {% if prop.items() | isArray %}
               {% for it in prop.items() %}
                 {{ schemaProp(it, loop.index0, odd=(not odd), required=(prop.required() | includes(pName))) }}
               {% endfor %}
             {% else %}
+            
               {{ schemaProp(prop.items(), '0', odd=(not odd)) }}
             {% endif %}
           {% endif %}
 
-          {% if prop.items() and arrayItemsProps %}        
+          {% if prop.items() and not arrayItemsProps | isEmpty %}   
             {% for pName, p in arrayItemsProps %}
               {% set isCirc = p.isCircular() %}
               {% if isCirc === true %}
@@ -182,7 +183,6 @@
             </div>
           {% endif %}
         {% endif %}
-
         {% if prop.type() === 'object' %}
           {% if prop.additionalProperties() === true or prop.additionalProperties() === undefined or prop.additionalProperties() === null %}
             <p class="pl-6 mb-2 mt-4 text-xs text-grey-darker">Additional properties are allowed.</p>
@@ -195,7 +195,6 @@
             </div>
           {% endif %}
         {% endif %}
-
         {% if prop.oneOf() %}
           {% for p in prop.oneOf() %}
             {{ schemaProp(p, loop.index0, odd=(not odd)) }}

--- a/partials/schema-prop.html
+++ b/partials/schema-prop.html
@@ -8,6 +8,10 @@
     <div class="{% if prop | isExpandable %}js-prop cursor-pointer py-2{% endif %} flex property">
       <div class="pr-4" style="margin-top:-2px; min-width: 25%;">
         <span class="text-sm{% if specialName %} italic text-grey{% endif %}{% if prop.deprecated() %} line-through{% endif %}" style="word-break: break-word;">{{propName}}</span>
+        {# Making sure that only human readable uid is rendered, instead of the anonymous ones that start with < #}
+        {% if not prop.uid() | startsWith('<') %}
+          <span class="border text-orange rounded text-xs ml-3 py-0 px-2">{{prop.uid()}}</span>
+        {% endif %}
         {% if prop | isExpandable %}
         <svg class="expand" version="1.1" viewBox="0 0 24 24" x="0"
           xmlns="http://www.w3.org/2000/svg" y="0">

--- a/partials/schema-prop.html
+++ b/partials/schema-prop.html
@@ -9,7 +9,7 @@
       <div class="pr-4" style="margin-top:-2px; min-width: 25%;">
         <span class="text-sm{% if specialName %} italic text-grey{% endif %}{% if prop.deprecated() %} line-through{% endif %}" style="word-break: break-word;">{{propName}}</span>
         {# Making sure that only human readable uid is rendered, instead of the anonymous ones that start with < #}
-        {% if not prop.uid() | startsWith('<') %}
+        {% if not prop.uid() | startsWith('<anonymous-') %}
           <span class="border text-orange rounded text-xs ml-3 py-0 px-2">{{prop.uid()}}</span>
         {% endif %}
         {% if prop | isExpandable %}

--- a/partials/type.html
+++ b/partials/type.html
@@ -8,6 +8,9 @@
     {%- for p in prop.items() -%}
       {{- type(p) -}}{% if not loop.last %}, {% endif %}
     {%- endfor -%}
+  {% elif prop.items().oneOf() %}oneOf
+  {% elif prop.items().allOf() %}allOf
+  {% elif prop.items().anyOf() %}anyOf
   {%- else -%}
     Unknown
   {%- endif -%}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Fix broken support for oneOf anyOf allOf in array items

**Related issue(s)**
Fixes https://github.com/asyncapi/playground/issues/36 https://github.com/asyncapi/generator/issues/427

this is how it is displayed now

![](https://user-images.githubusercontent.com/6995927/96149745-f5545880-0f09-11eb-8880-7335496cdc44.png)

for such a spec

```


asyncapi: 2.0.0
info:
  title: Test MQTT API
  version: '1.0.0'
  description: |
    Test


defaultContentType: application/json

channels:  
  foo/bar:
    description: Test MQTT operation
    publish:

      message:
        $ref: '#/components/messages/testMessage'
components:
  messages:
    testMessage:
      contentType: application/json
      payload:
        $ref: "#/components/schemas/mainSchema"
  schemas:
 
    oneOfSchema:
      type: object
      properties:
        foo:
          type: number
          format: float	
    oneOfSchema2:
      type: object
      properties:
        foo:
          type: number
          format: float	    

             
    mainSchema:
      type: object
      properties:
        mixedTypeArray:
          type: array
          items:
            oneOf:
            - $ref: "#/components/schemas/oneOfSchema"
            - $ref: "#/components/schemas/oneOfSchema2"
            - type: object
              properties:
                foo:
                  type: number
                  format: float	  

```
