### PR TITLE
fix: scalar types should not have a chevron icon indicating you can expand it

### DIFF
--- a/filters/all.js
+++ b/filters/all.js
@@ -14,7 +14,7 @@ function isExpandable(obj) {
     (fun(obj.additionalProperties) && obj.additionalProperties()) ||
     (fun(obj.extensions) && obj.extensions() &&
       Object.keys(obj.extensions()).filter(e => !e.startsWith("x-parser-")).length) ||
-    (fun(obj.patternProperties) && obj.patternProperties())
+    (fun(obj.patternProperties) && Object.keys(obj.patternProperties()).length)
   ) return true;
 
   return false;

--- a/test/all.is_expandable.test.js
+++ b/test/all.is_expandable.test.js
@@ -4,6 +4,7 @@ const {isExpandable} = require("../filters/all");
 test.beforeEach(t => {
   t.context.doc = {};
   t.context.types = [{ type: "string" }, { type: "number" }];
+  t.context.doc.patternProperties = () => ({});
 });
 
 test("isExpandable when the object type is object", t => {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

The scalar types are coming with an empty object in `patternProperties()` thus triggering the `isExpandable` filter. I changed the condition to verify if the object returned by `patternProperties()` is empty or not. It may be valid to also check why they are coming with it in the first place.

**Related issue**
Resolves #50 
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->