### PR TITLE
fix: add args to puppeteer to make pdf generation work in docker

### DIFF
--- a/hooks/generatePdf.js
+++ b/hooks/generatePdf.js
@@ -12,7 +12,7 @@ async function generatePdf(generator) {
     //all actions of this hook depend on parameters passed by the user, if non are provided we should just stop the hook
     if (!parameters || parameters.pdf !== 'true') return;
 
-    const browser = await puppeteer.launch();
+    const browser = await puppeteer.launch({args: ['--no-sandbox', '--disable-setuid-sandbox']});
     const page = await browser.newPage();
 
     await page.goto(`file://${path.join(targetDir, 'index.html')}`, { waitUntil: 'networkidle0' });


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- add args to puppeteer to make pdf generation work in docker

**Related issue(s)**
Fixes https://github.com/asyncapi/html-template/issues/112