### PR TITLE
fix: mark required props in object in array

### DIFF
--- a/partials/schema-prop.html
+++ b/partials/schema-prop.html
@@ -171,7 +171,7 @@
               {% if isCirc === true %}
                 {{ schemaItem(pName, odd) }}
               {% else %}
-                {{ schemaProp(p, pName, odd=(not odd), required=(prop.required() | includes(pName))) }} 
+                {{ schemaProp(p, pName, odd=(not odd), required=(prop.items().required() | includes(pName))) }} 
               {% endif %}
             {% endfor %}
           {% endif %}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- mark required props in object in array

**Related issue(s)**
See also https://github.com/asyncapi/playground/issues/43