### PR TITLE
fix: array with array of items throws error and only object is supported

### DIFF
--- a/partials/schema-prop.html
+++ b/partials/schema-prop.html
@@ -152,7 +152,8 @@
         {% endif %}
 
         {% if prop.type() === 'array' %}
-          {% set arrayItemsProps = (prop.items().properties() if prop.items() else null) %}
+
+          {% set arrayItemsProps = prop.items().properties() if prop.items() and not prop.items() | isArray else null %}
           {% if prop.items() and arrayItemsProps | isEmpty %}
             <p class="pl-6 mb-2 text-xs font-bold uppercase text-grey-darker">Items:</p>
             {% if prop.items() | isArray %}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- array with an array of items throws an error and only object is supported

I think I introduced the bug when I was adding support for circular refs. Good thing is though that we now regularly extend our dummy yaml file with more cases that need to be covered in tools -> https://github.com/asyncapi/generator/pull/443

**Related issue(s)**
Fixes https://github.com/asyncapi/generator/issues/441