### PR TITLE
fix: include main.css if not params.singleFile

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -20,6 +20,7 @@
   {% else %}
   <link href="css/tailwind.min.css" rel="stylesheet">
   <link rel="stylesheet" href="css/atom-one-dark.min.css" />
+  <link rel="stylesheet" href="css/main.css" />
   {% endif %}
 </head>
 <body>


### PR DESCRIPTION
Not a 100% sure, but I guess omitting main.css prohibits some commonmark renderings