### PR TITLE
fix: rendering of list items in markdown

### DIFF
--- a/partials/servers.html
+++ b/partials/servers.html
@@ -49,7 +49,7 @@
 
       {% if server.security() %}
         <h5 class="text-sm text-gray-500 mt-1">Security:</h5>
-        <ul class="list-reset">
+        <ul>
           {% for sec in server.security() %}
             <li>
               {% set def = asyncapi.components().securityScheme(sec.json() | keys | head) %}

--- a/partials/servers.html
+++ b/partials/servers.html
@@ -111,7 +111,7 @@
               {% endif %}
 
               {% if def.openIdConnectUrl() %}
-                <div class="px-4 py-2 ml-4 mb-3 border border-gray-400 bg-gray-200 rounded">
+                <div class="px-4 py-2 ml-4 mb-3 border border-gray-400 bg-gray-100 rounded">
                   <div>
                     <span class="text-xs font-bold text-gray-600 mt-1 mr-1 uppercase">Connect URL:</span>
                     <a class="text-gray-600 text-xs font-normal" href="{{def.openIdConnectUrl()}}"
@@ -122,7 +122,7 @@
               {% endif %}
 
               {% for flowName, flow in def.flows() %}
-                <div class="px-4 py-2 ml-4 mb-3 border border-gray-400 bg-gray-200 rounded">
+                <div class="px-4 py-2 ml-4 mb-3 border border-gray-400 bg-gray-100 rounded">
                   <div>
                     <span class="text-xs font-bold text-gray-600 mt-1 mr-1 uppercase">Flow:</span>
                     <span class="text-gray-600 text-xs font-normal capitalize">

--- a/partials/sidebar.html
+++ b/partials/sidebar.html
@@ -18,7 +18,7 @@
         {{ asyncapi.info().title() }} {{ asyncapi.info().version() }}
       </h1>
     {% endif %}
-    <ul class="text-sm mt-10 list-reset mt-2">
+    <ul class="text-sm mt-10 mt-2">
       <li class="mb-3">
         <a class="js-menu-item text-gray-700 no-underline" href="#introduction">Introduction</a>
       </li>
@@ -31,7 +31,7 @@
 
     {% if asyncapi.hasChannels() %}
       <h2 class="text-xs uppercase text-gray-500 mt-10 mb-4 font-thin">Operations</h2>
-      <ul class="text-sm list-reset mt-2">
+      <ul class="text-sm mt-2">
         <!-- With tags in sidebar -->
         {% if params.sidebarOrganization === 'byTags' %}
           {% include "./operations/by_tags.html" %}
@@ -81,7 +81,7 @@
       </ul>
 
       <h2 class="text-xs uppercase text-gray-500 mt-10 mb-4 font-thin">Messages</h2>
-      <ul class="text-sm list-reset mt-2">
+      <ul class="text-sm mt-2">
         {% for key, value in asyncapi.allMessages() %}
           <a class="js-menu-item flex break-words no-underline text-gray-700 mt-8 sm:mt-8 md:mt-3" href="#message-{{ key }}">
             <div style="display:inline-block;">

--- a/template/css/main.css
+++ b/template/css/main.css
@@ -91,6 +91,11 @@ a:hover {
   text-transform: uppercase;
 }
 
+.markdown :is(ol, ul) {
+  padding-inline-start: 40px;
+  list-style-type: disc;
+}
+
 .expand {
   width: 20px;
   margin-bottom: -4px;


### PR DESCRIPTION
**Description**
Due to the migration from tailwind v0.x to v2.x changed its default styling for lists ([see here](https://www.tailwindcss.cn/docs/upgrading-to-v1/#8-remove-any-usage-of-list-reset)). This does not affect the UI in general (like the `<ul>`in the sidebar), because list items were already rendered without bullet points. However, source from markup code should be displayed with bullet points and be intended.

**Related issue(s)**
Resolves #142 