### PR TITLE
feat: display protocol bindings on server, channel, operation, message

### DIFF
--- a/partials/message.html
+++ b/partials/message.html
@@ -1,5 +1,6 @@
 {% from "./schema.html" import schema %}
 {% from "./tags.html" import tags %}
+{% from "./protocols.html" import bindings %}
 
 {% macro message(msg, showIndex=false, index=0, open=false) %}
 
@@ -23,7 +24,6 @@
   {% if correlationId %}
     <div class="border border-gray-400 bg-gray-200 rounded p-4 mt-2">
       <div class="text-sm text-gray-700 mb-2">Correlation ID<span class="border text-orange-600 rounded text-xs ml-3 py-0 px-2">{{correlationId.location()}}</span>
-
       </div>
       {% if correlationId.hasDescription() %}
         <div class="text-gray-600 text-sm">{{correlationId.description() | markdown2html | safe }}</div>
@@ -40,6 +40,9 @@
       {{ schema(msg.headers(), 'Headers', open=open) }}
     </div>
   {% endif %}
+
+  {{ bindings("Message", msg, odd=true) }}
+
 </div>
 
 {% endmacro %}

--- a/partials/operation.html
+++ b/partials/operation.html
@@ -3,6 +3,7 @@
 {% from "./message.html" import message %}
 {% from "./example.html" import example %}
 {% from "./schema-prop.html" import schemaProp %}
+{% from "./protocols.html" import bindings %}
 
 
 {% macro operation(operation, operationType, channelName, channel) %}
@@ -26,6 +27,7 @@
     <p class="text-gray-500 text-sm">{{operation.summary()}}</p>
     <div class="mt-4 mb-4 markdown">{{ operation.description() | markdown2html | safe }}</div>
 
+    {{ bindings("Channel", channel) }}
 
 
     {% if channel.parameters() | length %}
@@ -50,6 +52,7 @@
       </div>
     {% endif %}
 
+    {{ bindings("Operation", channel) }}
 
     {% if operation.hasMultipleMessages() %}
     <p>Accepts <strong>one of</strong> the following messages:</p>

--- a/partials/operation.html
+++ b/partials/operation.html
@@ -52,7 +52,7 @@
       </div>
     {% endif %}
 
-    {{ bindings("Operation", channel) }}
+    {{ bindings("Operation", operation) }}
 
     {% if operation.hasMultipleMessages() %}
     <p>Accepts <strong>one of</strong> the following messages:</p>

--- a/partials/operations.html
+++ b/partials/operations.html
@@ -1,4 +1,6 @@
 {% from "./operation.html" import operation %}
+{% from "./protocols.html" import bindings %}
+
 
 <a name="operations"></a>
 <h2 class="mb-4 ml-8">Operations</h2>

--- a/partials/protocols.html
+++ b/partials/protocols.html
@@ -10,15 +10,15 @@
 {% endmacro %}
 
 
-{% macro bindings(eltName, elt, odd=false) %}
+{% macro bindings(propName, prop, odd=false) %}
 
-    {% if elt.hasBindings() %}
-        {% for protocol in elt.bindingProtocols() %}
-        <div class="{% if open %}is-open{% endif %}">
+    {% if prop.hasBindings() %}
+        {% for protocol in prop.bindingProtocols() %}
+        <div class="{% if open %}is-open{% endif %} mb-4">
             <div class="js-prop cursor-pointer py-2 property">
                 <div class="pr-4" style="margin-top: -2px; min-width: 25%">
                        <div class=" mt-4 text-sm">
-                            <span class="string-chunk">{{eltName}} specific information</span>
+                            <span class="string-chunk">{{propName}} specific information</span>
                             <svg
                                     class="expand inline align-baseline"
                                     version="1.1"
@@ -37,7 +37,7 @@
             </div>
 
             <div class="children">
-            {% for bindingName, bindingValue in elt.binding(protocol) %}
+            {% for bindingName, bindingValue in prop.binding(protocol) %}
                 <div class="{% if odd %}bg-gray-100{% else %}bg-gray-200{% endif %} pl-6">
                     {% if bindingValue | isObject %}
                     <div class="{% if open %}is-open{% endif %}">

--- a/partials/protocols.html
+++ b/partials/protocols.html
@@ -14,10 +14,10 @@
 
     {% if prop.hasBindings() %}
         {% for protocol in prop.bindingProtocols() %}
-        <div class="{% if open %}is-open{% endif %} mb-4">
+        <div class="{% if open %}is-open{% endif %} mt-4">
             <div class="js-prop cursor-pointer py-2 property">
                 <div class="pr-4" style="margin-top: -2px; min-width: 25%">
-                       <div class=" mt-4 text-sm">
+                       <div class="text-sm">
                             <span class="string-chunk">{{propName}} specific information</span>
                             <svg
                                     class="expand inline align-baseline"
@@ -36,9 +36,9 @@
                 </div>
             </div>
 
-            <div class="children">
+            <div class="children bg-gray-100 py-4 rounded">
             {% for bindingName, bindingValue in prop.binding(protocol) %}
-                <div class="{% if odd %}bg-gray-100{% else %}bg-gray-200{% endif %} pl-6">
+                <div class="{% if odd %}bg-gray-100{% else %}bg-gray-200{% endif %} pl-8 pr-8">
                     {% if bindingValue | isObject %}
                     <div class="{% if open %}is-open{% endif %}">
                         <div class="js-prop cursor-pointer py-2 property">

--- a/partials/protocols.html
+++ b/partials/protocols.html
@@ -10,7 +10,7 @@
 {% endmacro %}
 
 
-{% macro bindings(propName, prop, odd=false) %}
+{% macro bindings(propName, prop, odd=false, showProtocol=true) %}
 
     {% if prop.hasBindings() %}
         {% for protocol in prop.bindingProtocols() %}
@@ -31,7 +31,9 @@
                                         points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "
                                 ></polygon>
                             </svg>
+                           {% if showProtocol %}
                                {{ displayProtocol(protocol) }}
+                           {% endif %}
                         </div>
                 </div>
             </div>

--- a/partials/protocols.html
+++ b/partials/protocols.html
@@ -1,0 +1,81 @@
+{% macro displayProtocol(protocol, protocolVersion) %}
+    {% if protocolVersion %}
+    <span class="bg-teal-500 font-bold no-underline text-white uppercase rounded ml-2"
+          style="height: 20px;font-size: 11px;padding: 3px;">{{ protocol }}
+        {{ protocolVersion }}</span>
+    {% else %}
+    <span class="bg-teal-500 font-sans font-bold no-underline text-white uppercase rounded ml-2"
+          style="height: 20px;font-size: 11px;padding: 3px;">{{ protocol }}</span>
+    {% endif %}
+{% endmacro %}
+
+
+{% macro bindings(eltName, elt, odd=false) %}
+
+    {% if elt.hasBindings() %}
+        {% for protocol in elt.bindingProtocols() %}
+        <div class="{% if open %}is-open{% endif %}">
+            <div class="js-prop cursor-pointer py-2 property">
+                <div class="pr-4" style="margin-top: -2px; min-width: 25%">
+                       <div class=" mt-4 text-sm">
+                            <span class="string-chunk">{{eltName}} specific information</span>
+                            <svg
+                                    class="expand inline align-baseline"
+                                    version="1.1"
+                                    viewBox="0 0 24 24"
+                                    x="0"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    y="0"
+                            >
+                                <polygon
+                                        points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "
+                                ></polygon>
+                            </svg>
+                               {{ displayProtocol(protocol) }}
+                        </div>
+                </div>
+            </div>
+
+            <div class="children">
+            {% for bindingName, bindingValue in elt.binding(protocol) %}
+                <div class="{% if odd %}bg-gray-100{% else %}bg-gray-200{% endif %} pl-6">
+                    {% if bindingValue | isObject %}
+                    <div class="{% if open %}is-open{% endif %}">
+                        <div class="js-prop cursor-pointer py-2 property">
+                            <div class="pr-4" style="margin-top: -2px; min-width: 25%">
+                                <span class="text-sm" style="word-break: break-word"
+                                >{{ bindingName }}</span
+                                >
+                                <svg
+                                        class="expand inline align-baseline"
+                                        version="1.1"
+                                        viewBox="0 0 24 24"
+                                        x="0"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        y="0"
+                                >
+                                    <polygon
+                                            points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "
+                                    ></polygon>
+                                </svg>
+                            </div>
+                        </div>
+                        <div class="children">
+                            <div
+                                    class="{% if odd %}bg-gray-200{% else %}bg-gray-100{% endif %} {% if not root %}pl-8 pr-8{% endif %} rounded"
+                            >
+                                <pre class="text-sm">{{ bindingValue | dump(2) }}</pre>
+                            </div>
+                        </div>
+                    </div>
+                    {% else %}
+                    <div class="text-sm">{{ bindingName }}: {{ bindingValue }}</div>
+                    {% endif %}
+                </div>
+            {% endfor %}
+            </div>
+        </div>
+        {% endfor %}
+    {% endif %}
+
+{% endmacro %}

--- a/partials/servers.html
+++ b/partials/servers.html
@@ -1,4 +1,6 @@
 {% from "./sliced-string.html" import slicedString %}
+{% from "./protocols.html" import displayProtocol %}
+
 <a name="servers"></a>
 <div class="center-block p-8">
 
@@ -11,14 +13,7 @@
           <div class="pr-4 font-mono">
             {{ slicedString(server.url()) }}
 
-            {% if server.protocolVersion() %}
-            <span class="bg-teal-500 font-bold no-underline text-white uppercase rounded ml-2"
-              style="height: 20px;font-size: 11px;padding: 3px;">{{server.protocol()}}
-              {{server.protocolVersion()}}</span>
-            {% else %}
-            <span class="bg-teal-500 font-sans font-bold no-underline text-white uppercase rounded ml-2"
-              style="height: 20px;font-size: 11px;padding: 3px;">{{server.protocol()}}</span>
-            {% endif %}
+            {{ displayProtocol(server.protocol(), server.protocolVersion()) }}
           </div>
           <div class="text-xs text-gray-600">
             {{ server.description() | markdown2html | safe }}

--- a/partials/servers.html
+++ b/partials/servers.html
@@ -1,5 +1,6 @@
 {% from "./sliced-string.html" import slicedString %}
 {% from "./protocols.html" import displayProtocol %}
+{% from "./protocols.html" import bindings %}
 
 <a name="servers"></a>
 <div class="center-block p-8">
@@ -18,6 +19,9 @@
           <div class="text-xs text-gray-600">
             {{ server.description() | markdown2html | safe }}
           </div>
+
+          {{ bindings("Server", server, odd=true, showProtocol=false) }}
+
         </div>
       </div>
 


### PR DESCRIPTION


Here is the result with the dummy file on asyncapi/generator#556

Channel and operation bindings : 

![image](https://user-images.githubusercontent.com/5501911/114208287-983bdb80-995d-11eb-85d8-6cef643bb7bc.png)

By the way, it seems that settings bindings on a channel is not handle by the parser (see the dummy file content and the related generation)

For message bindings : 
![image](https://user-images.githubusercontent.com/5501911/113434775-dd9e5d00-93e1-11eb-9b3b-0cb5ef96d701.png)

![image](https://user-images.githubusercontent.com/5501911/113434790-e2631100-93e1-11eb-84fe-a76f6b776139.png)

![image](https://user-images.githubusercontent.com/5501911/113434853-0161a300-93e2-11eb-88b5-6302bdffe64d.png)

Resolves #25 
