### PR TITLE
fix: wrap long object dump when rendering binding info

### DIFF
--- a/partials/protocols.html
+++ b/partials/protocols.html
@@ -66,7 +66,7 @@
                             <div
                                     class="{% if odd %}bg-gray-200{% else %}bg-gray-100{% endif %} {% if not root %}pl-8 pr-8{% endif %} rounded"
                             >
-                                <pre class="text-sm">{{ bindingValue | dump(2) }}</pre>
+                                <pre class="text-sm whitespace-pre-wrap">{{ bindingValue | dump(2) }}</pre>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
stuff like this get very long and run outside the container:
```yml
    bindings:
      kafka:  
          x-key.subject.name.strategy:
            type: string
            description: |
              We use the **RecordNameStrategy** to infer the messages schema.
              Use `io.confluent.kafka.serializers.subject.RecordNameStrategy` for your consumer.
          x-value.subject.name.strategy:
            type: string
            description: |
              We use the **RecordNameStrategy** to infer the messages schema.
              Use `io.confluent.kafka.serializers.subject.RecordNameStrategy` for your consumer.
```