### PR TITLE
fix: add guard for asyncapi variable.

### DIFF
--- a/hooks/00_changeSpecVersion.js
+++ b/hooks/00_changeSpecVersion.js
@@ -3,6 +3,7 @@
  */
 module.exports = {
   'generate:before': ({ asyncapi, templateParams = {} }) => {
+    if (!asyncapi) return;
     const version = templateParams.version || asyncapi.info().version();
     asyncapi._json.info.version = version;
   }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

I am using the following packages:

```javascript
...
    "@asyncapi/generator": "^1.8.2",
    "@asyncapi/html-template": "^0.23.7",
    "@asyncapi/parser": "^1.7.0",
...
```

I am using this simple test script:

```javascript
const Generator = require('@asyncapi/generator');
const Parser = require('@asyncapi/parser');
const asyncApiDocument = require('./spec/ws.json');

const generator = new Generator(
  '@asyncapi/html-template',
  null,
  {
    entrypoint: 'index.html',
    output: 'string',
    // There seems to be a bug in this hook.
/*    disabledHooks: {
      'generate:before': [
        'generate:before',
      ],
    },*/
    templateParams: {
      singleFile: true,
    }
  }
);

Parser.parse(asyncApiDocument).then((doc) => {
  generator.generate(doc).then((html) => console.log(html));
});
```

I am receiving the following error:

```javascript
(node:1935853) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'info' of undefined
    at generate:before (/home/btimby/Code/node_modules/@asyncapi/html-template/hooks/00_changeSpecVersion.js:6:56)
    at /home/btimby/Code/node_modules/@asyncapi/generator/lib/generator.js:792:20
    at Array.map (<anonymous>)
    at Generator.launchHook (/home/btimby/Code/node_modules/@asyncapi/generator/lib/generator.js:789:28)
    at Generator.generate (/home/btimby/Code/node_modules/@asyncapi/generator/lib/generator.js:190:16)
```

I found that disabling the hook would avoid the error. Further, the change in this PR also seems to fix the issue. The problem is that the first argument to the hook is an instance of `Generator`, which does not have an `asyncapi` attribute, thus the `asyncapi` variable is undefined.

**Related issue(s)**

I could not find any.