### PR TITLE
feat: add option to override react config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install -g @asyncapi/generator
 | singleFile | Set output into one html-file with styles and scripts inside | No | `false` | `true`,`false` | `true` |
 | outFilename | The filename of the output file. | No | `index.html` | *Any* | `asyncapi.html` |
 | pdf | Generates output HTML as PDF | No | `false` | `true,false` | `false` |
-| config | Stringified JS object containing options for react | No | | null | *Any* | {"show":{ "sidebar":false}} |
+| config | Stringified JS object containing options for react | No | null | *Any* | {"show":{ "sidebar":false}} |
 
 > **NOTE**: If you only generate an HTML website, set the environment variable `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` to `true` and the generator will skip downloading chromium.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install -g @asyncapi/generator
 | singleFile | Set output into one html-file with styles and scripts inside | No | `false` | `true`,`false` | `true` |
 | outFilename | The filename of the output file. | No | `index.html` | *Any* | `asyncapi.html` |
 | pdf | Generates output HTML as PDF | No | `false` | `true,false` | `false` |
-| config | Stringified JS object containing options for react | No | null | *Any* | {"show":{ "sidebar":false}} |
+| config | Stringified JS object containing options for react | No | null | *Any* | {"show":{"sidebar":false}} |
 
 > **NOTE**: If you only generate an HTML website, set the environment variable `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` to `true` and the generator will skip downloading chromium.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install -g @asyncapi/generator
 | singleFile | Set output into one html-file with styles and scripts inside | No | `false` | `true`,`false` | `true` |
 | outFilename | The filename of the output file. | No | `index.html` | *Any* | `asyncapi.html` |
 | pdf | Generates output HTML as PDF | No | `false` | `true,false` | `false` |
-| config | Stringified JS object containing options for react | No | | null | *Any* | { "sidebar": false } |
+| config | Stringified JS object containing options for react | No | | null | *Any* | {"show":{ "sidebar":false}} |
 
 > **NOTE**: If you only generate an HTML website, set the environment variable `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` to `true` and the generator will skip downloading chromium.
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ npm install -g @asyncapi/generator
 | singleFile | Set output into one html-file with styles and scripts inside | No | `false` | `true`,`false` | `true` |
 | outFilename | The filename of the output file. | No | `index.html` | *Any* | `asyncapi.html` |
 | pdf | Generates output HTML as PDF | No | `false` | `true,false` | `false` |
+| config | Stringified JS object containing options for react | No | | null | *Any* | { "sidebar": false } |
 
 > **NOTE**: If you only generate an HTML website, set the environment variable `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` to `true` and the generator will skip downloading chromium.
 

--- a/filters/all.js
+++ b/filters/all.js
@@ -10,7 +10,10 @@ const filter = module.exports;
  * Prepares configuration for component.
  */
 function prepareConfiguration(params = {}) {
-  const config = { show: { sidebar: true }, sidebar: { showOperations: 'byDefault' } };
+  let config = { show: { sidebar: true }, sidebar: { showOperations: 'byDefault' } };
+  if (params.config) {
+    config = {...config, ...JSON.parse(params.config) };
+  }
   if (params.sidebarOrganization === 'byTags') {
     config.sidebar.showOperations = 'bySpecTags';
   }

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
         "default": false
       },
       "config": {
-        "description": "Stringified JS object containing options for react, ex: { \"sidebar\": false }.",
+        "description": "Stringified JS object containing options for react, ex: {\"show\":{\"sidebar\":false}}.",
         "default": null,
         "required": false
       }

--- a/package.json
+++ b/package.json
@@ -100,6 +100,11 @@
       "pdf": {
         "description": "Set to `true` to get index.pdf generated next to your index.html",
         "default": false
+      },
+      "config": {
+        "description": "Stringified JS object containing options for react, ex: { \"sidebar\": false }.",
+        "default": null,
+        "required": false
       }
     },
     "generator": ">=1.7.3 <2.0.0",

--- a/test/filters/all.test.js
+++ b/test/filters/all.test.js
@@ -112,6 +112,14 @@ describe('Filters', () => {
       const result = stringifyConfiguration(params);
       expect(result).toEqual(expected);
     });
+
+    it('should allow override of config', async () => {
+      const params = { config: '{"show": {"sidebar":false}}' };
+      const expected = '{"show":{"sidebar":false},"sidebar":{"showOperations":"byDefault"}}';
+
+      const result = stringifyConfiguration(params);
+      expect(result).toEqual(expected);
+    });
   });
 
   describe('.renderSpec', () => {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->
I have updated `README.md`, I am testing this change locally right now. I will follow up with results shortly.

**Description**

- Adds an option for `html-template` to define react config.
- Can be used to disable sidebar.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
https://github.com/asyncapi/html-template/issues/253