### PR TITLE
feat: fix maximum (1.8.19) version of generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
         "default": false
       }
     },
-    "generator": ">=1.7.3 <2.0.0",
+    "generator": ">=1.7.3 <=1.8.19",
     "nonRenderableFiles": [
       "js/asyncapi-ui.min.js"
     ]


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Fix maximum (1.8.19) version of generator - we need to merge https://github.com/asyncapi/parser-js/pull/391 PR but it will also bump the generator version and we need force the older versions of template to the given version of generator (to not having broken templates). After merging mentioned PR I will create PR in react-component to handle circular-references with new API and then we will bump html-template again.

`feat` not `fix` because we need at least major version - some breakpoint in development of html-template.