### PR TITLE
fix: move to synchronouse deletion of unnecessary files

### DIFF
--- a/hooks/01_removeNotRelevantParts.js
+++ b/hooks/01_removeNotRelevantParts.js
@@ -21,8 +21,8 @@ module.exports = {
         maxBusyTries: 3
       };
 
-      rimraf(jsDir, opts, callback);
-      rimraf(cssDir, opts, callback);
+      rimraf.sync(jsDir, opts, callback);
+      rimraf.sync(cssDir, opts, callback);
     }
   }
 };


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

As in title. In the [server-api](https://github.com/asyncapi/server-api) project we have problem when someone pass `singleFile` parameter and due to fact that given files are removed in async mode (without waiting) we can end up with situation when someone will get generated template with these files. 