### PR TITLE
docs: add instructions for using AsyncAPI CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,6 @@ HTML template for the [AsyncAPI Generator](https://github.com/asyncapi/generator
 
 ## Usage
 
-Install template
-
-```bash
-npm install -g @asyncapi/html-template@0.16.0
-```
-
 Install AsyncAPI CLI
 
 ```bash
@@ -39,7 +33,7 @@ npm install -g @asyncapi/cli
 Generate using CLI
 
 ```bash
-asyncapi generate fromTemplate asyncapi.yaml @asyncapi/html-template
+asyncapi generate fromTemplate asyncapi.yaml @asyncapi/html-template@0.16.0
 ```
 
 ## Supported parameters

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ asyncapi generate fromTemplate <asyncapi.yaml> @asyncapi/html-template@0.28.0
 ```
 
 You can replace <asyncapi.yaml> with local path or URL pointing to [any AsyncAPI document](https://raw.githubusercontent.com/asyncapi/spec/master/examples/streetlights-kafka.yml).
-Look into [Releases](/releases) of this template to pick up the version you need. It is not recommended to always use the latest in production. Always use a specific version.
+Look into [Releases](/asyncapi/html-template/releases) of this template to pick up the version you need. It is not recommended to always use the latest in production. Always use a specific version.
 
 ## Supported parameters
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ asyncapi generate fromTemplate <asyncapi.yaml> @asyncapi/html-template@0.28.0
 
 You can replace <asyncapi.yaml> with local path or URL pointing to [any AsyncAPI document](https://raw.githubusercontent.com/asyncapi/spec/master/examples/streetlights-kafka.yml).
 To use a specific version, look into [Releases](https://github.com/asyncapi/html-template/releases).
+Look into [Releases](/releases) of this template to pick up the version you need. It is not recommended to always use the latest in production. Always use a specific version.
 
 ## Supported parameters
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ npm install -g @asyncapi/cli
 Generate using CLI
 
 ```bash
-asyncapi generate fromTemplate asyncapi.yaml @asyncapi/html-template@0.16.0
+asyncapi generate fromTemplate <asyncapi.yaml> @asyncapi/html-template@0.16.0
 ```
+
+You can replace <asyncapi.yaml> with local path or URL pointing to [any AsyncAPI document](https://raw.githubusercontent.com/asyncapi/spec/master/examples/streetlights-kafka.yml).
 
 ## Supported parameters
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,18 @@ HTML template for the [AsyncAPI Generator](https://github.com/asyncapi/generator
 <!-- toc -->
 
 - [Usage](#usage)
+  - [Using Generator](#using-generator)
+  - [or](#or)
+  - [Using AsyncAPI CLI](#using-asyncapi-cli)
 - [Supported parameters](#supported-parameters)
 - [Development](#development)
-- [Contributors ✨](#contributors-%E2%9C%A8)
+- [Contributors ✨](#contributors-)
 
 <!-- tocstop -->
 
 ## Usage
+
+### Using Generator
 
 ```bash
 ag asyncapi.yaml @asyncapi/html-template -o output
@@ -32,6 +37,28 @@ If you don't have the AsyncAPI Generator installed, you can install it like this
 
 ```bash
 npm install -g @asyncapi/generator
+```
+
+### or 
+
+### Using AsyncAPI CLI
+
+Install template
+
+```bash
+npm install -g @asyncapi/html-template@0.16.0
+```
+
+Install AsyncAPI CLI
+
+```bash
+npm install -g @asyncapi/cli
+```
+
+Generate using CLI
+
+```bash
+asyncapi generate fromTemplate asyncapi.yaml @asyncapi/html-template
 ```
 
 ## Supported parameters

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Generate using CLI
 asyncapi generate fromTemplate <asyncapi.yaml> @asyncapi/html-template@0.28.0
 ```
 
-You can replace <asyncapi.yaml> with local path or URL pointing to [any AsyncAPI document](https://raw.githubusercontent.com/asyncapi/spec/master/examples/streetlights-kafka.yml).
+You can replace `<asyncapi.yaml>` with local path or URL pointing to [any AsyncAPI document](https://raw.githubusercontent.com/asyncapi/spec/master/examples/streetlights-kafka.yml).
 Look into [Releases](/asyncapi/html-template/releases) of this template to pick up the version you need. It is not recommended to always use the latest in production. Always use a specific version.
 
 ## Supported parameters

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ asyncapi generate fromTemplate <asyncapi.yaml> @asyncapi/html-template@0.28.0
 ```
 
 You can replace <asyncapi.yaml> with local path or URL pointing to [any AsyncAPI document](https://raw.githubusercontent.com/asyncapi/spec/master/examples/streetlights-kafka.yml).
-To use a specific version, look into [Releases](https://github.com/asyncapi/html-template/releases).
 Look into [Releases](/releases) of this template to pick up the version you need. It is not recommended to always use the latest in production. Always use a specific version.
 
 ## Supported parameters

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ asyncapi generate fromTemplate <asyncapi.yaml> @asyncapi/html-template@0.28.0
 ```
 
 You can replace <asyncapi.yaml> with local path or URL pointing to [any AsyncAPI document](https://raw.githubusercontent.com/asyncapi/spec/master/examples/streetlights-kafka.yml).
+To use a specific version, look into [Releases](https://github.com/asyncapi/html-template/releases).
 
 ## Supported parameters
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ HTML template for the [AsyncAPI Generator](https://github.com/asyncapi/generator
 <!-- toc -->
 
 - [Usage](#usage)
-  - [Using Generator](#using-generator)
-  - [or](#or)
-  - [Using AsyncAPI CLI](#using-asyncapi-cli)
 - [Supported parameters](#supported-parameters)
 - [Development](#development)
 - [Contributors ✨](#contributors-)
@@ -26,22 +23,6 @@ HTML template for the [AsyncAPI Generator](https://github.com/asyncapi/generator
 <!-- tocstop -->
 
 ## Usage
-
-### Using Generator
-
-```bash
-ag asyncapi.yaml @asyncapi/html-template -o output
-```
-
-If you don't have the AsyncAPI Generator installed, you can install it like this:
-
-```bash
-npm install -g @asyncapi/generator
-```
-
-### or 
-
-### Using AsyncAPI CLI
 
 Install template
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm install -g @asyncapi/cli
 Generate using CLI
 
 ```bash
-asyncapi generate fromTemplate <asyncapi.yaml> @asyncapi/html-template@0.16.0
+asyncapi generate fromTemplate <asyncapi.yaml> @asyncapi/html-template@0.28.0
 ```
 
 You can replace <asyncapi.yaml> with local path or URL pointing to [any AsyncAPI document](https://raw.githubusercontent.com/asyncapi/spec/master/examples/streetlights-kafka.yml).


### PR DESCRIPTION
**Description**
Previously the README contained instructions on how to use the template using Generator. I have added instructions on an alternate way of using the template using the AsyncAPI CLI.

Tagging @derberg 