### PR TITLE
feat: include `__transpiled` folder in the package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,4 @@ scripts
 sample
 vscode
 test
+!__transpiled

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "generate:readme:toc": "markdown-toc -i README.md",
     "bump:version": "npm --no-git-tag-version --allow-same-version version $VERSION",
     "copy:sources": "node ./scripts/copy-sources.js",
-    "prepublishOnly": "npm run generate:assets",
+    "prepublishOnly": "npm run generate:assets && npm run transpile",
+    "transpile": "node ./scripts/transpile.js",
     "test": "npm run test:library && npm run test:generator"
   },
   "publishConfig": {

--- a/scripts/transpile.js
+++ b/scripts/transpile.js
@@ -1,0 +1,16 @@
+const { transpileFiles } = require("@asyncapi/generator-react-sdk");
+const path = require("path");
+
+async function transpileTemplate() {
+  try {
+    const templateContentDir = path.join(__dirname, "../template");
+    console.log("Template content directory:", templateContentDir);
+    const outputDir = path.join(__dirname, "../__transpiled");
+    console.log("Output directory for transpiled files:", outputDir);
+    await transpileFiles(templateContentDir, outputDir, { recursive: true });
+  } catch (error) {
+    console.log("Error during template transpilation:", err)
+  }
+}
+
+transpileTemplate();


### PR DESCRIPTION

**Description**

- Include `__transpiled`  folder in publishing of the package 
- Have modified the `.npmignore` for including the transpiled folder

![image](https://github.com/asyncapi/html-template/assets/127925465/09ce2abd-f1df-4867-9f35-ca54f5061c26)


**Related issue(s)**
Resolves #575 
