### PR TITLE
fix: coerce singleFile strings->bools so non-singleFile won't bundle deps

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -9,14 +9,16 @@ export function Index({ asyncapi, params = {} }) {
   const favicon = generateBase64Favicon(params);
   const renderedSpec = renderSpec(asyncapi, params);
   let asyncapiScript = `<script src="js/asyncapi-ui.min.js" type="application/javascript"></script>`;
-  if(params?.singleFile) {
+  // coerce singleFile param to bool, or "false" string will be true
+  const singleFile = (params?.singleFile === true  || params?.singleFile == 'true');
+  if(singleFile) {
     asyncapiScript = `<script type="text/javascript">
     ${includeFile('template/js/asyncapi-ui.min.js')}
     </script>`;
   }
   let styling = `<link href="css/global.min.css" rel="stylesheet">
       <link href="css/asyncapi.min.css" rel="stylesheet">`;
-  if(params?.singleFile) {
+  if(singleFile) {
     styling = `<style type="text/css">
       ${includeFile("template/css/global.min.css")}
       ${includeFile("template/css/asyncapi.min.css")}
@@ -27,7 +29,7 @@ export function Index({ asyncapi, params = {} }) {
     basehref = `<base href="${params.baseHref}">`;
   }
   let appJs = `<script type="application/javascript" src="js/app.js"></script>`;
-  if(params?.singleFile) {
+  if(singleFile) {
     appJs = `<script>${App({asyncapi, params})}</script>`;
   }
   return (`<!DOCTYPE html>


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Currently html-template parses the string `'false'` as `true` because it is a non-empty string. This leads to the html file that is generated being created with its dependencies built in, when it should not.

By coercing this value to a boolean, this change ensures that only strings that match `'true'` or true boolean values will match the singleFile behaviour, and otherwise stick to the default non-singleFile behaviour. Other strings (including `'false'`) will generate non-singleFile documentation.

This behaviour satisfies the TypeScript contract which states that the value of the `singleFile` optional param must be a string. It does not solve the behaviour that if AsyncAPI/generator is given a singleFile param of a `false` boolean it will generate a non-singleFile formatted `index.html` while failing to also generate the dependency files non-singleFiles refer to. This is because A) fixing this behaviour appears to be outside of the html-template repo and B) that's outside of the aforementioned expected types supported, as per the TypeScript definition.

Using the [test repo](https://github.com/michael-ball-ctct/async-api-generator-singlefile-bug-demo) I created for #734 and pointing the template towards this repo will show a fixed case for `singleFileFalseString` (but not `singleFileFalseBoolean`, as discussed above).

**Related documentation**
None, other than the code comment explaining the coercion - which can be removed/amended if not fitting with repo style. This change is ensuring behaviour matches existing TypeScript + written documentation.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

Fixes #734 

**Test results**
```
 PASS  test/helpers/all.test.js
 PASS  test/components/index.test.js
------------|---------|----------|---------|---------|-----------------------------
File        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s           
------------|---------|----------|---------|---------|-----------------------------
All files   |      70 |    66.66 |     100 |   70.88 |                             
 components |   76.47 |       50 |     100 |   76.47 |                             
  index.js  |   76.47 |       50 |     100 |   76.47 | 15,22,29,33                 
 helpers    |   68.25 |    73.33 |     100 |   69.35 |                             
  all.js    |   68.25 |    73.33 |     100 |   69.35 | 18,22,45-50,103-117,163-166 
------------|---------|----------|---------|---------|-----------------------------

Test Suites: 2 passed, 2 total
Tests:       13 passed, 13 total
Snapshots:   4 passed, 4 total
Time:        2.707 s
Ran all test suites.
```