### PR TITLE
docs: fix README incorrect Chromium skip env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Look into [Releases](/asyncapi/html-template/releases) of this template to pick 
 | favicon | Defines the URL/Path used for the favicon. | No | `assets/asyncapi-favicon.ico` | Any valid favicon URL/Path. | `"https://studio.asyncapi.com/favicon.ico"` |
 | config | Inline stringified JSON or a path to a JSON file to override default React component config. The config override is merged with the default config using the [JSON Merge Patch](https://tools.ietf.org/html/rfc7386) algorithm. | No | `{ "show": { "sidebar": true }, "sidebar": { "showOperations": "byDefault" } }` | [JSON config for the React component](https://github.com/asyncapi/asyncapi-react/blob/master/docs/configuration/config-modification.md#definition) | `{"show":{"sidebar":false}}` |
 
-> **NOTE**: If you only generate an HTML website, set the environment variable `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` to `true` and the generator will skip downloading chromium.
+> **NOTE**: If you only generate an HTML website, set the environment variable `PUPPETEER_SKIP_DOWNLOAD` to `true` and the generator will skip downloading chromium.
 
 ## Development
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Updated the `README.md` to fix an incorrect environment variable (`PUPPETEER_SKIP_CHROMIUM_DOWNLOAD`) under the Puppeteer setup section.
- Replaced it with the correct variable, `PUPPETEER_SKIP_DOWNLOAD`, according to the latest Puppeteer documentation ([puppeteer.configuration#skipdownload](https://pptr.dev/api/puppeteer.configuration#skipdownload)).
- Added a brief note explaining the reasoning for this correction.

**Related issue(s)**
Fixes #794