### PR TITLE
fix(docs): correct Puppeteer env var from PUPPETEER_SKIP_CHROMIUM_DOWNLOAD to PUPPETEER_SKIP_DOWNLOAD (#794)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Look into [Releases](/asyncapi/html-template/releases) of this template to pick 
 | favicon | Defines the URL/Path used for the favicon. | No | `assets/asyncapi-favicon.ico` | Any valid favicon URL/Path. | `"https://studio.asyncapi.com/favicon.ico"` |
 | config | Inline stringified JSON or a path to a JSON file to override default React component config. The config override is merged with the default config using the [JSON Merge Patch](https://tools.ietf.org/html/rfc7386) algorithm. | No | `{ "show": { "sidebar": true }, "sidebar": { "showOperations": "byDefault" } }` | [JSON config for the React component](https://github.com/asyncapi/asyncapi-react/blob/master/docs/configuration/config-modification.md#definition) | `{"show":{"sidebar":false}}` |
 
-> **NOTE**: If you only generate an HTML website, set the environment variable `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` to `true` and the generator will skip downloading chromium.
+> **NOTE**: If you only generate an HTML website, set the environment variable `PUPPETEER_SKIP_DOWNLOAD` to `true` and the generator will skip downloading chromium.
 
 ## Development
 


### PR DESCRIPTION
## Problem

**Fixes #794**

The README instructs users to set `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true`, but this environment variable is **deprecated** in puppeteer@^24.4.0. Setting it has no effect — Chromium is still downloaded.

## Fix

Replace with `PUPPETEER_SKIP_DOWNLOAD=true`, which is the correct variable in modern Puppeteer versions.

## Verification

- [Puppeteer docs](https://pptr.dev/troubleshooting#running-puppeteer-on-gitlab-ci) confirm `PUPPETEER_SKIP_DOWNLOAD` is the correct variable
- Tested locally: `PUPPETEER_SKIP_DOWNLOAD=true npm install` correctly skips Chromium download